### PR TITLE
Fix nullability error for Xcode 8.3.

### DIFF
--- a/Source/GTMTVAuthorizationResponse.m
+++ b/Source/GTMTVAuthorizationResponse.m
@@ -99,7 +99,7 @@ static NSString *const kRequestKey = @"request";
 
 #pragma mark - Initializers
 
-- (nullable instancetype)init
+- (instancetype)init
     OID_UNAVAILABLE_USE_INITIALIZER(@selector(initWithRequest:parameters:));
 
 - (nullable instancetype)initWithRequest:(GTMTVAuthorizationRequest *)request


### PR DESCRIPTION
Fixing a `Conflicting nullability specifier on return types` error for Xcode 8.3+.

Ran across this when compiling https://github.com/google/google-api-objectivec-client-for-rest