### PR TITLE
Bump required AppAuth version for iOS 11 support

### DIFF
--- a/GTMAppAuth.podspec
+++ b/GTMAppAuth.podspec
@@ -44,5 +44,5 @@ requests with AppAuth.
 
   s.frameworks = 'Security', 'SystemConfiguration'
   s.dependency 'GTMSessionFetcher', '~> 1.1'
-  s.dependency 'AppAuth', '~> 0.9.0'
+  s.dependency 'AppAuth', '~> 0.90.0'
 end


### PR DESCRIPTION
See https://github.com/openid/AppAuth-iOS/releases