### PR TITLE
Don't specify platforms in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,12 +21,6 @@ import PackageDescription
 
 let package = Package(
     name: "GTMAppAuth",
-    platforms: [
-        .macOS(.v10_11),
-        .iOS(.v8),
-        .tvOS(.v9),
-        .watchOS(.v6)
-    ],
     products: [
         .library(
             name: "GTMAppAuth",


### PR DESCRIPTION
This fixes #106, and there's some more info in the issue.

The problem is that the downstream dependency https://github.com/google/gtm-session-fetcher did this very change [here](https://github.com/google/gtm-session-fetcher/commit/67ba34f8d540029c0c19cd2bf6d092ca9be0527f#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e), which was included in their 1.5.0 release.
Since this package depends on 1.4.0..<2.0.0 of GTMSessionFetcher 1.5.0 will automatically be fetched, since that's the latest release that supports this, and the problems in #106 appear.

I've verified that this fix solves the problem for me, in a iOS XCode-project with iOS13+, using SPM for dependencies. But I'm not familiar enough with the project to reason about the impacts this might have. But since the current version is pretty much broken with SPM I think this should make things better in any case.