### PR TITLE
Fix Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     name: "GTMAppAuth",
     platforms: [
         .macOS(.v10_11),
-        .iOS(.v8),
+        .iOS(.v9),
         .tvOS(.v9),
         .watchOS(.v6)
     ],

--- a/Source/GTMOAuth2KeychainCompatibility/GTMOAuth2KeychainCompatibility.h
+++ b/Source/GTMOAuth2KeychainCompatibility/GTMOAuth2KeychainCompatibility.h
@@ -16,10 +16,10 @@
         limitations under the License.
  */
 
-#if SWIFT_PACKAGE
-#import "../GTMAppAuthFetcherAuthorization.h"
-#else
+#if COCOAPODS
 #import "GTMAppAuthFetcherAuthorization.h"
+#else
+#import "../GTMAppAuthFetcherAuthorization.h"
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Source/SwiftPackage/GTMAppAuth/GTMAppAuth.h
+++ b/Source/SwiftPackage/GTMAppAuth/GTMAppAuth.h
@@ -1,0 +1,1 @@
+../../GTMAppAuth.h

--- a/Source/SwiftPackage/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
+++ b/Source/SwiftPackage/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
@@ -1,0 +1,1 @@
+../../GTMAppAuthFetcherAuthorization+Keychain.h

--- a/Source/SwiftPackage/GTMAppAuth/GTMAppAuthFetcherAuthorization.h
+++ b/Source/SwiftPackage/GTMAppAuth/GTMAppAuthFetcherAuthorization.h
@@ -1,0 +1,1 @@
+../../GTMAppAuthFetcherAuthorization.h

--- a/Source/SwiftPackage/GTMAppAuth/GTMOAuth2KeychainCompatibility.h
+++ b/Source/SwiftPackage/GTMAppAuth/GTMOAuth2KeychainCompatibility.h
@@ -1,0 +1,1 @@
+../../GTMOAuth2KeychainCompatibility/GTMOAuth2KeychainCompatibility.h

--- a/Source/SwiftPackage/module.modulemap
+++ b/Source/SwiftPackage/module.modulemap
@@ -1,8 +1,0 @@
-module GTMAppAuth {
-    header "../GTMAppAuthFetcherAuthorization.h"
-    header "../GTMAppAuthFetcherAuthorization+Keychain.h"
-    header "../GTMKeychain.h"
-    header "../GTMOAuth2KeychainCompatibility/GTMOAuth2KeychainCompatibility.h"
-
-    export *
-}


### PR DESCRIPTION
Hi,

The current release installed via SPM cannot build.
This PR contains the following changes to fix that:
- Increment deployment target iOS 8 to iOS 9
- Fix import conditions to import a header correctly
- Change the structure of public headers directory

Resolve #106, resolve #107 

Note: This fix isn't enough to be able to build, because GTMSessionFetcher's SPM support has an issue too (https://github.com/google/gtm-session-fetcher/pull/220).