### PR TITLE
Fix pod lib lint

### DIFF
--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization.h
@@ -18,10 +18,12 @@
 
 #if !defined(__has_include)
   #error "__has_include not available."
+#elif __has_include(<GTMSessionFetcher/GTMSessionFetcher.h>)
+  #import <GTMSessionFetcher/GTMSessionFetcher.h>
 #elif __has_include("../GTMSessionFetcher.h")
   #import "../GTMSessionFetcher.h"
 #else
-  #import <GTMSessionFetcher/GTMSessionFetcher.h>
+# error "Failed to find GTMSessionFetcher"
 #endif
 
 @class OIDAuthState;


### PR DESCRIPTION
Strangely, the order of the `__has_include` checks matters.

I confirmed that this succeeds `pod lib lint` with and without the `--use-libraries` option and SPM still builds.