### PR TITLE
Add GTMKeychain.h to umbrella header

### DIFF
--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuth.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuth.h
@@ -18,13 +18,11 @@
 
 #import "GTMAppAuthFetcherAuthorization.h"
 #import "GTMAppAuthFetcherAuthorization+Keychain.h"
-#import "GTMKeychain.h"
 
 #if TARGET_OS_TV
 #elif TARGET_OS_WATCH
-#elif TARGET_OS_IOS
-#import "GTMOAuth2KeychainCompatibility.h"
-#elif TARGET_OS_MAC
+#elif TARGET_OS_IOS || TARGET_OS_MAC
+#import "GTMKeychain.h"
 #import "GTMOAuth2KeychainCompatibility.h"
 #else
 #warn "Platform Undefined"

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuth.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuth.h
@@ -18,6 +18,7 @@
 
 #import "GTMAppAuthFetcherAuthorization.h"
 #import "GTMAppAuthFetcherAuthorization+Keychain.h"
+#import "GTMKeychain.h"
 
 #if TARGET_OS_TV
 #elif TARGET_OS_WATCH


### PR DESCRIPTION
This is required for Xcode 12.5 and Swift Package Manager. Verified locally that this fix resolves the issue.