### PR TITLE
Update revocation, token, userinfo endpoints

### DIFF
--- a/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.m
+++ b/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.m
@@ -222,7 +222,7 @@ static NSString *const kExampleAuthorizerKey = @"authorization";
   fetcherService.authorizer = self.authorization;
 
   // Creates a fetcher for the API call.
-  NSURL *userinfoEndpoint = [NSURL URLWithString:@"https://www.googleapis.com/oauth2/v3/userinfo"];
+  NSURL *userinfoEndpoint = [NSURL URLWithString:@"https://openidconnect.googleapis.com/v1/userinfo"];
   GTMSessionFetcher *fetcher = [fetcherService fetcherWithURL:userinfoEndpoint];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
     // Checks for an error.

--- a/Examples/Example-macOS/Source/GTMAppAuthExampleViewController.m
+++ b/Examples/Example-macOS/Source/GTMAppAuthExampleViewController.m
@@ -228,7 +228,7 @@ static NSString *const kExampleAuthorizerKey = @"authorization";
   fetcherService.authorizer = self.authorization;
 
   // Creates a fetcher for the API call.
-  NSURL *userinfoEndpoint = [NSURL URLWithString:@"https://www.googleapis.com/oauth2/v3/userinfo"];
+  NSURL *userinfoEndpoint = [NSURL URLWithString:@"https://openidconnect.googleapis.com/v1/userinfo"];
   GTMSessionFetcher *fetcher = [fetcherService fetcherWithURL:userinfoEndpoint];
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
 

--- a/GTMAppAuth/Sources/GTMAppAuthFetcherAuthorization.m
+++ b/GTMAppAuth/Sources/GTMAppAuthFetcherAuthorization.m
@@ -198,7 +198,7 @@ NSString *const GTMAppAuthFetcherAuthorizationErrorRequestKey = @"request";
   NSURL *authorizationEndpoint =
       [NSURL URLWithString:@"https://accounts.google.com/o/oauth2/v2/auth"];
   NSURL *tokenEndpoint =
-      [NSURL URLWithString:@"https://www.googleapis.com/oauth2/v4/token"];
+      [NSURL URLWithString:@"https://oauth2.googleapis.com/token"];
 
   OIDServiceConfiguration *configuration =
       [[OIDServiceConfiguration alloc] initWithAuthorizationEndpoint:authorizationEndpoint

--- a/GTMAppAuth/Sources/GTMOAuth2KeychainCompatibility.m
+++ b/GTMAppAuth/Sources/GTMOAuth2KeychainCompatibility.m
@@ -308,17 +308,17 @@ static NSString *const kOOBString = @"urn:ietf:wg:oauth:2.0:oob";
 }
 
 + (NSURL *)googleTokenURL {
-  NSString *str = @"https://www.googleapis.com/oauth2/v4/token";
+  NSString *str = @"https://oauth2.googleapis.com/token";
   return (NSURL *)[NSURL URLWithString:str];
 }
 
 + (NSURL *)googleRevocationURL {
-  NSString *urlStr = @"https://accounts.google.com/o/oauth2/revoke";
+  NSString *urlStr = @"https://oauth2.googleapis.com/revoke";
   return (NSURL *)[NSURL URLWithString:urlStr];
 }
 
 + (NSURL *)googleUserInfoURL {
-  NSString *urlStr = @"https://www.googleapis.com/oauth2/v3/userinfo";
+  NSString *urlStr = @"https://openidconnect.googleapis.com/v1/userinfo";
   return (NSURL *)[NSURL URLWithString:urlStr];
 }
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ directly:
 NSURL *authorizationEndpoint =
     [NSURL URLWithString:@"https://accounts.google.com/o/oauth2/v2/auth"];
 NSURL *tokenEndpoint =
-    [NSURL URLWithString:@"https://www.googleapis.com/oauth2/v4/token"];
+    [NSURL URLWithString:@"https://oauth2.googleapis.com/token"];
 
 OIDServiceConfiguration *configuration =
     [[OIDServiceConfiguration alloc]
@@ -193,7 +193,7 @@ GTMSessionFetcherService *fetcherService = [[GTMSessionFetcherService alloc] ini
 fetcherService.authorizer = self.authorization;
 
 // Creates a fetcher for the API call.
-NSURL *userinfoEndpoint = [NSURL URLWithString:@"https://www.googleapis.com/oauth2/v3/userinfo"];
+NSURL *userinfoEndpoint = [NSURL URLWithString:@"https://openidconnect.googleapis.com/v1/userinfo"];
 GTMSessionFetcher *fetcher = [fetcherService fetcherWithURL:userinfoEndpoint];
 [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
   // Checks for an error.


### PR DESCRIPTION
Update revocation, token, userinfo endpoint URIs based on the latest published OIDC Discovery document
https://accounts.google.com/.well-known/openid-configuration