### PR TITLE
Handle errSecDuplicateItem in savePassword on macOS

### DIFF
--- a/GTMAppAuth/Sources/macOS/GTMKeychain_macOS.m
+++ b/GTMAppAuth/Sources/macOS/GTMKeychain_macOS.m
@@ -106,6 +106,9 @@ static const char *kKeychainAccountName = "OAuth";
 }
 
 + (BOOL)removePasswordFromKeychainForName:(NSString *)keychainItemName {
+  // before accessing the keychain, check preferences to verify that we've
+  // previously saved a token to the keychain (so we don't needlessly raise
+  // a keychain access permission dialog)
   NSString *prefKey = [self prefsKeyForName:keychainItemName];
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   if (![defaults boolForKey:prefKey]) {
@@ -139,7 +142,7 @@ static const char *kKeychainAccountName = "OAuth";
 }
 
 + (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName password:(NSString *)password {
-  // Remove the existing key to prevent the keychain error: errSecDuplicateItem.
+  // Remove any existing entry to prevent the keychain error: errSecDuplicateItem.
   [self removePasswordFromKeychainForName:keychainItemName];
 
   SecKeychainRef defaultKeychain = NULL;
@@ -166,7 +169,7 @@ static const char *kKeychainAccountName = "OAuth";
 
 + (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
                              passwordData:(NSData *)passwordData {
-  // Remove the existing key to prevent the keychain error: errSecDuplicateItem.
+  // Remove any existing entry to prevent the keychain error: errSecDuplicateItem.
   [self removePasswordFromKeychainForName:keychainItemName];
 
   SecKeychainRef defaultKeychain = NULL;

--- a/GTMAppAuth/Sources/macOS/GTMKeychain_macOS.m
+++ b/GTMAppAuth/Sources/macOS/GTMKeychain_macOS.m
@@ -40,8 +40,7 @@ static const char *kKeychainAccountName = "OAuth";
   // a keychain access permission dialog)
   NSString *prefKey = [self prefsKeyForName:keychainItemName];
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-  BOOL flag = [defaults boolForKey:prefKey];
-  if (!flag) {
+  if (![defaults boolForKey:prefKey]) {
     return nil;
   }
 
@@ -78,8 +77,7 @@ static const char *kKeychainAccountName = "OAuth";
   // a keychain access permission dialog)
   NSString *prefKey = [self prefsKeyForName:keychainItemName];
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-  BOOL flag = [defaults boolForKey:prefKey];
-  if (!flag) {
+  if (![defaults boolForKey:prefKey]) {
     return nil;
   }
 
@@ -108,6 +106,12 @@ static const char *kKeychainAccountName = "OAuth";
 }
 
 + (BOOL)removePasswordFromKeychainForName:(NSString *)keychainItemName {
+  NSString *prefKey = [self prefsKeyForName:keychainItemName];
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  if (![defaults boolForKey:prefKey]) {
+    return YES;
+  }
+
   SecKeychainRef defaultKeychain = NULL;
   SecKeychainItemRef itemRef = NULL;
   const char *utf8ServiceName = [keychainItemName UTF8String];
@@ -128,8 +132,6 @@ static const char *kKeychainAccountName = "OAuth";
     CFRelease(itemRef);
 
     // remove our preference key
-    NSString *prefKey = [self prefsKeyForName:keychainItemName];
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults removeObjectForKey:prefKey];
 
     return (err == noErr);
@@ -137,6 +139,9 @@ static const char *kKeychainAccountName = "OAuth";
 }
 
 + (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName password:(NSString *)password {
+  // Remove the existing key to prevent the keychain error: errSecDuplicateItem.
+  [self removePasswordFromKeychainForName:keychainItemName];
+
   SecKeychainRef defaultKeychain = NULL;
   SecKeychainItemRef *dontWantItemRef= NULL;
   const char *utf8ServiceName = [keychainItemName UTF8String];
@@ -161,6 +166,9 @@ static const char *kKeychainAccountName = "OAuth";
 
 + (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
                              passwordData:(NSData *)passwordData {
+  // Remove the existing key to prevent the keychain error: errSecDuplicateItem.
+  [self removePasswordFromKeychainForName:keychainItemName];
+
   SecKeychainRef defaultKeychain = NULL;
   SecKeychainItemRef *dontWantItemRef= NULL;
   const char *utf8ServiceName = [keychainItemName UTF8String];


### PR DESCRIPTION
Fix the error errSecDuplicateItem. Now adding password for the existing account the old one would be overwritten. 