### PR TITLE
Allow developers to use the data protection keychain on macOS

### DIFF
--- a/GTMAppAuth/Sources/GTMAppAuthFetcherAuthorization+Keychain.m
+++ b/GTMAppAuth/Sources/GTMAppAuthFetcherAuthorization+Keychain.m
@@ -23,7 +23,14 @@
 @implementation GTMAppAuthFetcherAuthorization (Keychain)
 
 + (GTMAppAuthFetcherAuthorization *)authorizationFromKeychainForName:(NSString *)keychainItemName {
-  NSData *passwordData = [GTMKeychain passwordDataFromKeychainForName:keychainItemName];
+  return [GTMAppAuthFetcherAuthorization authorizationFromKeychainForName:keychainItemName
+                                               withDataProtectionKeychain:NO];
+}
+
++ (GTMAppAuthFetcherAuthorization *)authorizationFromKeychainForName:(NSString *)keychainItemName
+                                          withDataProtectionKeychain:(BOOL)dataProtectionKeychain {
+  NSData *passwordData = [GTMKeychain passwordDataFromKeychainForName:keychainItemName
+                                           withDataProtectionKeychain:dataProtectionKeychain];
   if (!passwordData) {
     return nil;
   }
@@ -33,14 +40,30 @@
 }
 
 + (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName {
-  return [GTMKeychain removePasswordFromKeychainForName:keychainItemName];
+  return [GTMAppAuthFetcherAuthorization removeAuthorizationFromKeychainForName:keychainItemName
+                                                     withDataProtectionKeychain:NO];
+}
+
++ (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName
+                    withDataProtectionKeychain:(BOOL)dataProtectionKeychain {
+  return [GTMKeychain removePasswordFromKeychainForName:keychainItemName
+                             withDataProtectionKeychain:dataProtectionKeychain];
 }
 
 + (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth
         toKeychainForName:(NSString *)keychainItemName {
+  return [GTMAppAuthFetcherAuthorization saveAuthorization:auth
+                                         toKeychainForName:keychainItemName
+                                withDataProtectionKeychain:NO];
+}
+
++ (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth
+             toKeychainForName:(NSString *)keychainItemName
+    withDataProtectionKeychain:(BOOL)dataProtectionKeychain {
   NSData *authorizationData = [NSKeyedArchiver archivedDataWithRootObject:auth];
   return [GTMKeychain savePasswordDataToKeychainForName:keychainItemName
-                                           passwordData:authorizationData];
+                                           passwordData:authorizationData
+                             withDataProtectionKeychain:dataProtectionKeychain];
 }
 
 @end

--- a/GTMAppAuth/Sources/GTMAppAuthFetcherAuthorization+Keychain.m
+++ b/GTMAppAuth/Sources/GTMAppAuthFetcherAuthorization+Keychain.m
@@ -26,14 +26,14 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMAppAuthFetcherAuthorization authorizationFromKeychainForName:keychainItemName
-                                               withDataProtectionKeychain:NO];
+                                                   dataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (GTMAppAuthFetcherAuthorization *)authorizationFromKeychainForName:(NSString *)keychainItemName
-                                          withDataProtectionKeychain:(BOOL)dataProtectionKeychain {
+                                              dataProtectionKeychain:(BOOL)dataProtectionKeychain {
   NSData *passwordData = [GTMKeychain passwordDataFromKeychainForName:keychainItemName
-                                           withDataProtectionKeychain:dataProtectionKeychain];
+                                               dataProtectionKeychain:dataProtectionKeychain];
   if (!passwordData) {
     return nil;
   }
@@ -46,14 +46,14 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMAppAuthFetcherAuthorization removeAuthorizationFromKeychainForName:keychainItemName
-                                                     withDataProtectionKeychain:NO];
+                                                        dataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName
-                    withDataProtectionKeychain:(BOOL)dataProtectionKeychain {
+                        dataProtectionKeychain:(BOOL)dataProtectionKeychain {
   return [GTMKeychain removePasswordFromKeychainForName:keychainItemName
-                             withDataProtectionKeychain:dataProtectionKeychain];
+                                 dataProtectionKeychain:dataProtectionKeychain];
 }
 
 + (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth
@@ -62,17 +62,17 @@
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMAppAuthFetcherAuthorization saveAuthorization:auth
                                          toKeychainForName:keychainItemName
-                                withDataProtectionKeychain:NO];
+                                    dataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth
              toKeychainForName:(NSString *)keychainItemName
-    withDataProtectionKeychain:(BOOL)dataProtectionKeychain {
+        dataProtectionKeychain:(BOOL)dataProtectionKeychain {
   NSData *authorizationData = [NSKeyedArchiver archivedDataWithRootObject:auth];
   return [GTMKeychain savePasswordDataToKeychainForName:keychainItemName
                                            passwordData:authorizationData
-                             withDataProtectionKeychain:dataProtectionKeychain];
+                                 dataProtectionKeychain:dataProtectionKeychain];
 }
 
 @end

--- a/GTMAppAuth/Sources/GTMAppAuthFetcherAuthorization+Keychain.m
+++ b/GTMAppAuth/Sources/GTMAppAuthFetcherAuthorization+Keychain.m
@@ -26,14 +26,14 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMAppAuthFetcherAuthorization authorizationFromKeychainForName:keychainItemName
-                                                   dataProtectionKeychain:NO];
+                                                useDataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (GTMAppAuthFetcherAuthorization *)authorizationFromKeychainForName:(NSString *)keychainItemName
-                                              dataProtectionKeychain:(BOOL)dataProtectionKeychain {
+                                           useDataProtectionKeychain:(BOOL)useDataProtectionKeychain {
   NSData *passwordData = [GTMKeychain passwordDataFromKeychainForName:keychainItemName
-                                               dataProtectionKeychain:dataProtectionKeychain];
+                                            useDataProtectionKeychain:useDataProtectionKeychain];
   if (!passwordData) {
     return nil;
   }
@@ -46,14 +46,14 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMAppAuthFetcherAuthorization removeAuthorizationFromKeychainForName:keychainItemName
-                                                        dataProtectionKeychain:NO];
+                                                      useDataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName
-                        dataProtectionKeychain:(BOOL)dataProtectionKeychain {
+                     useDataProtectionKeychain:(BOOL)useDataProtectionKeychain {
   return [GTMKeychain removePasswordFromKeychainForName:keychainItemName
-                                 dataProtectionKeychain:dataProtectionKeychain];
+                              useDataProtectionKeychain:useDataProtectionKeychain];
 }
 
 + (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth
@@ -62,17 +62,17 @@
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMAppAuthFetcherAuthorization saveAuthorization:auth
                                          toKeychainForName:keychainItemName
-                                    dataProtectionKeychain:NO];
+                                 useDataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth
              toKeychainForName:(NSString *)keychainItemName
-        dataProtectionKeychain:(BOOL)dataProtectionKeychain {
+     useDataProtectionKeychain:(BOOL)useDataProtectionKeychain {
   NSData *authorizationData = [NSKeyedArchiver archivedDataWithRootObject:auth];
   return [GTMKeychain savePasswordDataToKeychainForName:keychainItemName
                                            passwordData:authorizationData
-                                 dataProtectionKeychain:dataProtectionKeychain];
+                              useDataProtectionKeychain:useDataProtectionKeychain];
 }
 
 @end

--- a/GTMAppAuth/Sources/GTMAppAuthFetcherAuthorization+Keychain.m
+++ b/GTMAppAuth/Sources/GTMAppAuthFetcherAuthorization+Keychain.m
@@ -23,8 +23,11 @@
 @implementation GTMAppAuthFetcherAuthorization (Keychain)
 
 + (GTMAppAuthFetcherAuthorization *)authorizationFromKeychainForName:(NSString *)keychainItemName {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMAppAuthFetcherAuthorization authorizationFromKeychainForName:keychainItemName
                                                withDataProtectionKeychain:NO];
+#pragma clang diagnostic pop
 }
 
 + (GTMAppAuthFetcherAuthorization *)authorizationFromKeychainForName:(NSString *)keychainItemName
@@ -40,8 +43,11 @@
 }
 
 + (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMAppAuthFetcherAuthorization removeAuthorizationFromKeychainForName:keychainItemName
                                                      withDataProtectionKeychain:NO];
+#pragma clang diagnostic pop
 }
 
 + (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName
@@ -52,9 +58,12 @@
 
 + (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth
         toKeychainForName:(NSString *)keychainItemName {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMAppAuthFetcherAuthorization saveAuthorization:auth
                                          toKeychainForName:keychainItemName
                                 withDataProtectionKeychain:NO];
+#pragma clang diagnostic pop
 }
 
 + (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth

--- a/GTMAppAuth/Sources/GTMKeychain.m
+++ b/GTMAppAuth/Sources/GTMKeychain.m
@@ -26,7 +26,7 @@
 
 // When set to YES, all Keychain queries will have
 // kSecUseDataProtectionKeychain set to true on macOS 10.15+.  Defaults to NO.
-@property(nonatomic) BOOL dataProtectionKeychain;
+@property(nonatomic) BOOL useDataProtectionKeychain;
 
 + (GTMAppAuthGTMOAuth2Keychain *)defaultKeychain;
 
@@ -80,7 +80,7 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 + (BOOL)removePasswordFromKeychainForName:(NSString *)keychainItemName
                    dataProtectionKeychain:(BOOL)dataProtectionKeychain {
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
-  keychain.dataProtectionKeychain = dataProtectionKeychain;
+  keychain.useDataProtectionKeychain = dataProtectionKeychain;
   return [keychain removePasswordForService:keychainItemName
                                     account:kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName
                                       error:nil];
@@ -96,7 +96,7 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 + (NSString *)passwordFromKeychainForName:(NSString *)keychainItemName
                    dataProtectionKeychain:(BOOL)dataProtectionKeychain {
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
-  keychain.dataProtectionKeychain = dataProtectionKeychain;
+  keychain.useDataProtectionKeychain = dataProtectionKeychain;
   NSError *error;
   NSString *password =
       [keychain passwordForService:keychainItemName
@@ -120,7 +120,7 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
                dataProtectionKeychain:(BOOL)dataProtectionKeychain {
   CFTypeRef accessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
-  keychain.dataProtectionKeychain = dataProtectionKeychain;
+  keychain.useDataProtectionKeychain = dataProtectionKeychain;
   return [keychain setPassword:password
                     forService:keychainItemName
                  accessibility:accessibility
@@ -143,7 +143,7 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
                    dataProtectionKeychain:(BOOL)dataProtectionKeychain {
   CFTypeRef accessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
-  keychain.dataProtectionKeychain = dataProtectionKeychain;
+  keychain.useDataProtectionKeychain = dataProtectionKeychain;
   return [keychain setPasswordData:password
                         forService:keychainItemName
                      accessibility:accessibility
@@ -162,7 +162,7 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 + (NSData *)passwordDataFromKeychainForName:(NSString *)keychainItemName
                      dataProtectionKeychain:(BOOL)dataProtectionKeychain {
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
-  keychain.dataProtectionKeychain = dataProtectionKeychain;
+  keychain.useDataProtectionKeychain = dataProtectionKeychain;
   NSError *error;
   NSData *password =
       [keychain passwordDataForService:keychainItemName
@@ -189,7 +189,7 @@ static GTMAppAuthGTMOAuth2Keychain* gGTMAppAuthFetcherAuthorizationGTMOAuth2Defa
 - (instancetype)init {
   self = [super init];
   if (self) {
-    _dataProtectionKeychain = NO;
+    _useDataProtectionKeychain = NO;
   }
   return self;
 }
@@ -219,7 +219,7 @@ static GTMAppAuthGTMOAuth2Keychain* gGTMAppAuthFetcherAuthorizationGTMOAuth2Defa
   // set it here only when supported by the Apple SDK and when relevant at runtime.
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
   if (@available(macOS 10.15, *)) {
-    if (self.dataProtectionKeychain) {
+    if (self.useDataProtectionKeychain) {
       [query setObject:(id)kCFBooleanTrue forKey:(id)kSecUseDataProtectionKeychain];
     }
   }

--- a/GTMAppAuth/Sources/GTMKeychain.m
+++ b/GTMAppAuth/Sources/GTMKeychain.m
@@ -73,12 +73,12 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMKeychain removePasswordFromKeychainForName:keychainItemName
-                             withDataProtectionKeychain:NO];
+                                 dataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (BOOL)removePasswordFromKeychainForName:(NSString *)keychainItemName
-               withDataProtectionKeychain:(BOOL)dataProtectionKeychain {
+                   dataProtectionKeychain:(BOOL)dataProtectionKeychain {
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
   keychain.dataProtectionKeychain = dataProtectionKeychain;
   return [keychain removePasswordForService:keychainItemName
@@ -89,12 +89,12 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 + (NSString *)passwordFromKeychainForName:(NSString *)keychainItemName {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
-  return [GTMKeychain passwordFromKeychainForName:keychainItemName withDataProtectionKeychain:NO];
+  return [GTMKeychain passwordFromKeychainForName:keychainItemName dataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (NSString *)passwordFromKeychainForName:(NSString *)keychainItemName
-               withDataProtectionKeychain:(BOOL)dataProtectionKeychain {
+                   dataProtectionKeychain:(BOOL)dataProtectionKeychain {
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
   keychain.dataProtectionKeychain = dataProtectionKeychain;
   NSError *error;
@@ -111,13 +111,13 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMKeychain savePasswordToKeychainForName:keychainItemName
                                            password:password
-                         withDataProtectionKeychain:NO];
+                             dataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName
                              password:(NSString *)password
-           withDataProtectionKeychain:(BOOL)dataProtectionKeychain {
+               dataProtectionKeychain:(BOOL)dataProtectionKeychain {
   CFTypeRef accessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
   keychain.dataProtectionKeychain = dataProtectionKeychain;
@@ -134,13 +134,13 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMKeychain savePasswordDataToKeychainForName:keychainItemName
                                            passwordData:password
-                             withDataProtectionKeychain:NO];
+                                 dataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
                              passwordData:(NSData *)password
-               withDataProtectionKeychain:(BOOL)dataProtectionKeychain {
+                   dataProtectionKeychain:(BOOL)dataProtectionKeychain {
   CFTypeRef accessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
   keychain.dataProtectionKeychain = dataProtectionKeychain;
@@ -155,12 +155,12 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMKeychain passwordDataFromKeychainForName:keychainItemName
-                           withDataProtectionKeychain:NO];
+                               dataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (NSData *)passwordDataFromKeychainForName:(NSString *)keychainItemName
-                 withDataProtectionKeychain:(BOOL)dataProtectionKeychain {
+                     dataProtectionKeychain:(BOOL)dataProtectionKeychain {
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
   keychain.dataProtectionKeychain = dataProtectionKeychain;
   NSError *error;

--- a/GTMAppAuth/Sources/GTMKeychain.m
+++ b/GTMAppAuth/Sources/GTMKeychain.m
@@ -200,6 +200,8 @@ static GTMAppAuthGTMOAuth2Keychain* gGTMAppAuthFetcherAuthorizationGTMOAuth2Defa
                                                         account, (id)kSecAttrAccount,
                                                         service, (id)kSecAttrService,
                                                         nil];
+  // kSecUseDataProtectionKeychain is a no-op on platforms other than macOS 10.15+.  For clarity, we
+  // set it here only when supported by the Apple SDK and when relevant at runtime.
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
   if (@available(macOS 10.15, *)) {
     if (self.dataProtectionKeychain) {

--- a/GTMAppAuth/Sources/GTMKeychain.m
+++ b/GTMAppAuth/Sources/GTMKeychain.m
@@ -194,10 +194,6 @@ static GTMAppAuthGTMOAuth2Keychain* gGTMAppAuthFetcherAuthorizationGTMOAuth2Defa
   }
 }
 
-- (NSString *)keyForService:(NSString *)service account:(NSString *)account {
-  return [NSString stringWithFormat:@"com.google.GTMOAuth.%@%@", service, account];
-}
-
 - (NSMutableDictionary *)keychainQueryForService:(NSString *)service account:(NSString *)account {
   NSMutableDictionary *query =
       [NSMutableDictionary dictionaryWithObjectsAndKeys:(id)kSecClassGenericPassword, (id)kSecClass,

--- a/GTMAppAuth/Sources/GTMKeychain.m
+++ b/GTMAppAuth/Sources/GTMKeychain.m
@@ -70,8 +70,11 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 @implementation GTMKeychain
 
 + (BOOL)removePasswordFromKeychainForName:(NSString *)keychainItemName {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMKeychain removePasswordFromKeychainForName:keychainItemName
                              withDataProtectionKeychain:NO];
+#pragma clang diagnostic pop
 }
 
 + (BOOL)removePasswordFromKeychainForName:(NSString *)keychainItemName
@@ -84,7 +87,10 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 }
 
 + (NSString *)passwordFromKeychainForName:(NSString *)keychainItemName {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMKeychain passwordFromKeychainForName:keychainItemName withDataProtectionKeychain:NO];
+#pragma clang diagnostic pop
 }
 
 + (NSString *)passwordFromKeychainForName:(NSString *)keychainItemName
@@ -101,9 +107,12 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 
 + (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName
                              password:(NSString *)password {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMKeychain savePasswordToKeychainForName:keychainItemName
                                            password:password
                          withDataProtectionKeychain:NO];
+#pragma clang diagnostic pop
 }
 
 + (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName
@@ -121,9 +130,12 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 
 + (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
                              passwordData:(NSData *)password {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMKeychain savePasswordDataToKeychainForName:keychainItemName
                                            passwordData:password
                              withDataProtectionKeychain:NO];
+#pragma clang diagnostic pop
 }
 
 + (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
@@ -140,8 +152,11 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 }
 
 + (NSData *)passwordDataFromKeychainForName:(NSString *)keychainItemName {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMKeychain passwordDataFromKeychainForName:keychainItemName
                            withDataProtectionKeychain:NO];
+#pragma clang diagnostic pop
 }
 
 + (NSData *)passwordDataFromKeychainForName:(NSString *)keychainItemName

--- a/GTMAppAuth/Sources/GTMKeychain.m
+++ b/GTMAppAuth/Sources/GTMKeychain.m
@@ -73,14 +73,14 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMKeychain removePasswordFromKeychainForName:keychainItemName
-                                 dataProtectionKeychain:NO];
+                              useDataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (BOOL)removePasswordFromKeychainForName:(NSString *)keychainItemName
-                   dataProtectionKeychain:(BOOL)dataProtectionKeychain {
+                useDataProtectionKeychain:(BOOL)useDataProtectionKeychain {
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
-  keychain.useDataProtectionKeychain = dataProtectionKeychain;
+  keychain.useDataProtectionKeychain = useDataProtectionKeychain;
   return [keychain removePasswordForService:keychainItemName
                                     account:kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName
                                       error:nil];
@@ -89,14 +89,14 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 + (NSString *)passwordFromKeychainForName:(NSString *)keychainItemName {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
-  return [GTMKeychain passwordFromKeychainForName:keychainItemName dataProtectionKeychain:NO];
+  return [GTMKeychain passwordFromKeychainForName:keychainItemName useDataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (NSString *)passwordFromKeychainForName:(NSString *)keychainItemName
-                   dataProtectionKeychain:(BOOL)dataProtectionKeychain {
+                useDataProtectionKeychain:(BOOL)useDataProtectionKeychain {
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
-  keychain.useDataProtectionKeychain = dataProtectionKeychain;
+  keychain.useDataProtectionKeychain = useDataProtectionKeychain;
   NSError *error;
   NSString *password =
       [keychain passwordForService:keychainItemName
@@ -111,16 +111,16 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMKeychain savePasswordToKeychainForName:keychainItemName
                                            password:password
-                             dataProtectionKeychain:NO];
+                          useDataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName
                              password:(NSString *)password
-               dataProtectionKeychain:(BOOL)dataProtectionKeychain {
+            useDataProtectionKeychain:(BOOL)useDataProtectionKeychain {
   CFTypeRef accessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
-  keychain.useDataProtectionKeychain = dataProtectionKeychain;
+  keychain.useDataProtectionKeychain = useDataProtectionKeychain;
   return [keychain setPassword:password
                     forService:keychainItemName
                  accessibility:accessibility
@@ -134,16 +134,16 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMKeychain savePasswordDataToKeychainForName:keychainItemName
                                            passwordData:password
-                                 dataProtectionKeychain:NO];
+                              useDataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
                              passwordData:(NSData *)password
-                   dataProtectionKeychain:(BOOL)dataProtectionKeychain {
+                useDataProtectionKeychain:(BOOL)useDataProtectionKeychain {
   CFTypeRef accessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
-  keychain.useDataProtectionKeychain = dataProtectionKeychain;
+  keychain.useDataProtectionKeychain = useDataProtectionKeychain;
   return [keychain setPasswordData:password
                         forService:keychainItemName
                      accessibility:accessibility
@@ -155,14 +155,14 @@ static NSString *const kGTMAppAuthFetcherAuthorizationGTMOAuth2AccountName = @"O
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
   return [GTMKeychain passwordDataFromKeychainForName:keychainItemName
-                               dataProtectionKeychain:NO];
+                            useDataProtectionKeychain:NO];
 #pragma clang diagnostic pop
 }
 
 + (NSData *)passwordDataFromKeychainForName:(NSString *)keychainItemName
-                     dataProtectionKeychain:(BOOL)dataProtectionKeychain {
+                  useDataProtectionKeychain:(BOOL)useDataProtectionKeychain {
   GTMAppAuthGTMOAuth2Keychain *keychain = [GTMAppAuthGTMOAuth2Keychain defaultKeychain];
-  keychain.useDataProtectionKeychain = dataProtectionKeychain;
+  keychain.useDataProtectionKeychain = useDataProtectionKeychain;
   NSError *error;
   NSData *password =
       [keychain passwordDataForService:keychainItemName

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable GTMAppAuthFetcherAuthorization *)
     authorizationFromKeychainForName:(NSString *)keychainItemName
-          withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
+          withDataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
 
 /*! @brief Removes a stored authorization state.
     @param keychainItemName The keychain name.
@@ -57,7 +57,8 @@ NS_ASSUME_NONNULL_BEGIN
     @return YES the tokens were removed successfully (or didn't exist).
  */
 + (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName
-                    withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
+                    withDataProtectionKeychain:(BOOL)dataProtectionKeychain
+    API_AVAILABLE(macosx(10.15));
 
 /*! @brief Saves the authorization state to the keychain, in GTMAppAuth format.
     @param auth The authorization to save.
@@ -76,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth
              toKeychainForName:(NSString *)keychainItemName
-    withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
+    withDataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
 
 @end
 

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
@@ -37,13 +37,13 @@ NS_ASSUME_NONNULL_BEGIN
         in GTMAppAuth format.  Note that if you choose to start using the data protection keychain on
         macOS, any items previously created will not be accessible without migration.
     @param keychainItemName The keychain name.
-    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
-        keychain on macOS 10.15+.
+    @param useDataProtectionKeychain A Boolean value that indicates whether to use the data
+        protection keychain on macOS 10.15+.
     @return A @c GTMAppAuthFetcherAuthorization object, or nil.
  */
 + (nullable GTMAppAuthFetcherAuthorization *)
     authorizationFromKeychainForName:(NSString *)keychainItemName
-              dataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
+           useDataProtectionKeychain:(BOOL)useDataProtectionKeychain API_AVAILABLE(macosx(10.15));
 
 /*! @brief Removes a stored authorization state.
     @param keychainItemName The keychain name.
@@ -55,12 +55,12 @@ NS_ASSUME_NONNULL_BEGIN
         protection keychain on macOS, any items previously created will not be accessible without
         migration.
     @param keychainItemName The keychain name.
-    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
-        keychain on macOS 10.15+.
+    @param useDataProtectionKeychain A Boolean value that indicates whether to use the data
+        protection keychain on macOS 10.15+.
     @return YES if the tokens were removed successfully (or didn't exist).
  */
 + (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName
-                        dataProtectionKeychain:(BOOL)dataProtectionKeychain
+                     useDataProtectionKeychain:(BOOL)useDataProtectionKeychain
     API_AVAILABLE(macosx(10.15));
 
 /*! @brief Saves the authorization state to the keychain, in GTMAppAuth format.
@@ -76,13 +76,13 @@ NS_ASSUME_NONNULL_BEGIN
         will not be accessible without migration.
     @param auth The authorization to save.
     @param keychainItemName The keychain name.
-    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
-        keychain on macOS 10.15+.
+    @param useDataProtectionKeychain A Boolean value that indicates whether to use the data
+        protection keychain on macOS 10.15+.
     @return YES when the state was saved successfully.
  */
 + (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth
              toKeychainForName:(NSString *)keychainItemName
-        dataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
+     useDataProtectionKeychain:(BOOL)useDataProtectionKeychain API_AVAILABLE(macosx(10.15));
 
 @end
 

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable GTMAppAuthFetcherAuthorization *)
     authorizationFromKeychainForName:(NSString *)keychainItemName
-          withDataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
+              dataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
 
 /*! @brief Removes a stored authorization state.
     @param keychainItemName The keychain name.
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
     @return YES if the tokens were removed successfully (or didn't exist).
  */
 + (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName
-                    withDataProtectionKeychain:(BOOL)dataProtectionKeychain
+                        dataProtectionKeychain:(BOOL)dataProtectionKeychain
     API_AVAILABLE(macosx(10.15));
 
 /*! @brief Saves the authorization state to the keychain, in GTMAppAuth format.
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth
              toKeychainForName:(NSString *)keychainItemName
-    withDataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
+        dataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
 
 @end
 

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
@@ -34,7 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
     authorizationFromKeychainForName:(NSString *)keychainItemName;
 
 /*! @brief Attempts to create a @c GTMAppAuthFetcherAuthorization from data stored in the keychain
-        in GTMAppAuth format.
+        in GTMAppAuth format.  Note that if you choose to start using the data protection keychain on
+        macOS, any items previously created will not be accessible without migration.
     @param keychainItemName The keychain name.
     @param dataProtectionKeychain Whether or not to use the data protection
         keychain on macOS 10.15+.
@@ -50,7 +51,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName;
 
-/*! @brief Removes a stored authorization state.
+/*! @brief Removes a stored authorization state.  Note that if you choose to start using the data
+        protection keychain on macOS, any items previously created will not be accessible without
+        migration.
     @param keychainItemName The keychain name.
     @param dataProtectionKeychain Whether or not to use the data protection
         keychain on macOS 10.15+.
@@ -68,7 +71,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth
         toKeychainForName:(NSString *)keychainItemName;
 
-/*! @brief Saves the authorization state to the keychain, in GTMAppAuth format.
+/*! @brief Saves the authorization state to the keychain, in GTMAppAuth format.  Note that if you
+        choose to start using the data protection keychain on macOS, any items previously created
+        will not be accessible without migration.
     @param auth The authorization to save.
     @param keychainItemName The keychain name.
     @param dataProtectionKeychain Whether or not to use the data protection

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
@@ -33,11 +33,31 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable GTMAppAuthFetcherAuthorization *)
     authorizationFromKeychainForName:(NSString *)keychainItemName;
 
+/*! @brief Attempts to create a @c GTMAppAuthFetcherAuthorization from data stored in the keychain
+        in GTMAppAuth format.
+    @param keychainItemName The keychain name.
+    @param dataProtectionKeychain Whether or not to use the data protection
+        keychain on macOS 10.15+.
+    @return A @c GTMAppAuthFetcherAuthorization object, or nil.
+ */
++ (nullable GTMAppAuthFetcherAuthorization *)
+    authorizationFromKeychainForName:(NSString *)keychainItemName
+          withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
+
 /*! @brief Removes a stored authorization state.
     @param keychainItemName The keychain name.
     @return YES the tokens were removed successfully (or didn't exist).
  */
 + (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName;
+
+/*! @brief Removes a stored authorization state.
+    @param keychainItemName The keychain name.
+    @param dataProtectionKeychain Whether or not to use the data protection
+        keychain on macOS 10.15+.
+    @return YES the tokens were removed successfully (or didn't exist).
+ */
++ (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName
+                    withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
 
 /*! @brief Saves the authorization state to the keychain, in GTMAppAuth format.
     @param auth The authorization to save.
@@ -46,6 +66,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth
         toKeychainForName:(NSString *)keychainItemName;
+
+/*! @brief Saves the authorization state to the keychain, in GTMAppAuth format.
+    @param auth The authorization to save.
+    @param keychainItemName The keychain name.
+    @param dataProtectionKeychain Whether or not to use the data protection
+        keychain on macOS 10.15+.
+    @return YES when the state was saved successfully.
+ */
++ (BOOL)saveAuthorization:(GTMAppAuthFetcherAuthorization *)auth
+             toKeychainForName:(NSString *)keychainItemName
+    withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
 
 @end
 

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*! @brief Removes a stored authorization state.
     @param keychainItemName The keychain name.
-    @return YES the tokens were removed successfully (or didn't exist).
+    @return YES if the tokens were removed successfully (or didn't exist).
  */
 + (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName;
 
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
     @param keychainItemName The keychain name.
     @param dataProtectionKeychain Whether or not to use the data protection
         keychain on macOS 10.15+.
-    @return YES the tokens were removed successfully (or didn't exist).
+    @return YES if the tokens were removed successfully (or didn't exist).
  */
 + (BOOL)removeAuthorizationFromKeychainForName:(NSString *)keychainItemName
                     withDataProtectionKeychain:(BOOL)dataProtectionKeychain

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization+Keychain.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
         in GTMAppAuth format.  Note that if you choose to start using the data protection keychain on
         macOS, any items previously created will not be accessible without migration.
     @param keychainItemName The keychain name.
-    @param dataProtectionKeychain Whether or not to use the data protection
+    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
         keychain on macOS 10.15+.
     @return A @c GTMAppAuthFetcherAuthorization object, or nil.
  */
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
         protection keychain on macOS, any items previously created will not be accessible without
         migration.
     @param keychainItemName The keychain name.
-    @param dataProtectionKeychain Whether or not to use the data protection
+    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
         keychain on macOS 10.15+.
     @return YES if the tokens were removed successfully (or didn't exist).
  */
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
         will not be accessible without migration.
     @param auth The authorization to save.
     @param keychainItemName The keychain name.
-    @param dataProtectionKeychain Whether or not to use the data protection
+    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
         keychain on macOS 10.15+.
     @return YES when the state was saved successfully.
  */

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
@@ -29,7 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
     @param password Password string to save.
     @return YES when the password string was saved successfully.
  */
-+ (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName password:(NSString *)password;
++ (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName
+                             password:(NSString *)password;
 
 /*! @brief Saves the password string to the keychain with the given identifier.
     @param keychainItemName Keychain name of the item.
@@ -40,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName
                              password:(NSString *)password
-           withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
+           withDataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
 
 /*! @brief Loads the password string from the keychain with the given identifier.
     @param keychainItemName Keychain name of the item.
@@ -55,7 +56,8 @@ NS_ASSUME_NONNULL_BEGIN
     @return The password string at the given identifier, or nil.
  */
 + (nullable NSString *)passwordFromKeychainForName:(NSString *)keychainItemName
-                        withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
+                        withDataProtectionKeychain:(BOOL)dataProtectionKeychain
+    API_AVAILABLE(macosx(10.15));
 
 /*! @brief Saves the password data to the keychain with the given identifier.
     @param keychainItemName Keychain name of the item.
@@ -74,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
                              passwordData:(NSData *)passwordData
-               withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
+               withDataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
 
 /*! @brief Loads the password data from the keychain with the given identifier.
     @param keychainItemName Keychain name of the item.
@@ -89,7 +91,8 @@ NS_ASSUME_NONNULL_BEGIN
     @return The password data at the given identifier, or nil.
  */
 + (nullable NSData *)passwordDataFromKeychainForName:(NSString *)keychainItemName
-                          withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
+                          withDataProtectionKeychain:(BOOL)dataProtectionKeychain
+    API_AVAILABLE(macosx(10.15));
 
 /*! @brief Removes stored password string, such as when the user signs out.
     @param keychainItemName Keychain name of the item.
@@ -104,7 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
     @return YES if the password string was removed successfully (or didn't exist).
  */
 + (BOOL)removePasswordFromKeychainForName:(NSString *)keychainItemName
-               withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
+               withDataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
 
 @end
 

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
@@ -32,7 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName
                              password:(NSString *)password;
 
-/*! @brief Saves the password string to the keychain with the given identifier.
+/*! @brief Saves the password string to the keychain with the given identifier.  Note that if you
+        choose to start using the data protection keychain on macOS, any items previously created
+        will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
     @param password Password string to save.
     @param dataProtectionKeychain Whether or not to use the data protection
@@ -49,7 +51,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable NSString *)passwordFromKeychainForName:(NSString *)keychainItemName;
 
-/*! @brief Loads the password string from the keychain with the given identifier.
+/*! @brief Loads the password string from the keychain with the given identifier.  Note that if you
+        choose to start using the data protection keychain on macOS, any items previously created
+        will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
     @param dataProtectionKeychain Whether or not to use the data protection
         keychain on macOS 10.15+.
@@ -67,7 +71,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
                              passwordData:(NSData *)passwordData;
 
-/*! @brief Saves the password data to the keychain with the given identifier.
+/*! @brief Saves the password data to the keychain with the given identifier.  Note that if you
+        choose to start using the data protection keychain on macOS, any items previously created
+        will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
     @param passwordData Password data to save.
     @param dataProtectionKeychain Whether or not to use the data protection
@@ -84,7 +90,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable NSData *)passwordDataFromKeychainForName:(NSString *)keychainItemName;
 
-/*! @brief Loads the password data from the keychain with the given identifier.
+/*! @brief Loads the password data from the keychain with the given identifier.  Note that if you
+        choose to start using the data protection keychain on macOS, any items previously created
+        will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
     @param dataProtectionKeychain Whether or not to use the data protection
         keychain on macOS 10.15+.
@@ -100,7 +108,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)removePasswordFromKeychainForName:(NSString *)keychainItemName;
 
-/*! @brief Removes stored password string, such as when the user signs out.
+/*! @brief Removes stored password string, such as when the user signs out.  Note that if you
+        choose to start using the data protection keychain on macOS, any items previously created
+        will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
     @param dataProtectionKeychain Whether or not to use the data protection
         keychain on macOS 10.15+.

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*! @brief Saves the password string to the keychain with the given identifier.
     @param keychainItemName Keychain name of the item.
     @param password Password string to save.
-    @return YES when the password string was saved successfully.
+    @return YES if the password string was saved successfully.
  */
 + (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName
                              password:(NSString *)password;
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
     @param password Password string to save.
     @param dataProtectionKeychain Whether or not to use the data protection
         keychain on macOS 10.15+.
-    @return YES when the password string was saved successfully.
+    @return YES if the password string was saved successfully.
  */
 + (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName
                              password:(NSString *)password
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*! @brief Saves the password data to the keychain with the given identifier.
     @param keychainItemName Keychain name of the item.
     @param passwordData Password data to save.
-    @return YES when the password data was saved successfully.
+    @return YES if the password data was saved successfully.
  */
 + (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
                              passwordData:(NSData *)passwordData;
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
     @param passwordData Password data to save.
     @param dataProtectionKeychain Whether or not to use the data protection
         keychain on macOS 10.15+.
-    @return YES when the password data was saved successfully.
+    @return YES if the password data was saved successfully.
  */
 + (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
                              passwordData:(NSData *)passwordData

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName
                              password:(NSString *)password
-           withDataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
+               dataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
 
 /*! @brief Loads the password string from the keychain with the given identifier.
     @param keychainItemName Keychain name of the item.
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
     @return The password string at the given identifier, or nil.
  */
 + (nullable NSString *)passwordFromKeychainForName:(NSString *)keychainItemName
-                        withDataProtectionKeychain:(BOOL)dataProtectionKeychain
+                            dataProtectionKeychain:(BOOL)dataProtectionKeychain
     API_AVAILABLE(macosx(10.15));
 
 /*! @brief Saves the password data to the keychain with the given identifier.
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
                              passwordData:(NSData *)passwordData
-               withDataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
+                   dataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
 
 /*! @brief Loads the password data from the keychain with the given identifier.
     @param keychainItemName Keychain name of the item.
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
     @return The password data at the given identifier, or nil.
  */
 + (nullable NSData *)passwordDataFromKeychainForName:(NSString *)keychainItemName
-                          withDataProtectionKeychain:(BOOL)dataProtectionKeychain
+                              dataProtectionKeychain:(BOOL)dataProtectionKeychain
     API_AVAILABLE(macosx(10.15));
 
 /*! @brief Removes stored password string, such as when the user signs out.
@@ -117,7 +117,7 @@ NS_ASSUME_NONNULL_BEGIN
     @return YES if the password string was removed successfully (or didn't exist).
  */
 + (BOOL)removePasswordFromKeychainForName:(NSString *)keychainItemName
-               withDataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
+                   dataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
 
 @end
 

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
@@ -37,13 +37,13 @@ NS_ASSUME_NONNULL_BEGIN
         will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
     @param password Password string to save.
-    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
-        keychain on macOS 10.15+.
+    @param useDataProtectionKeychain A Boolean value that indicates whether to use the data
+        protection keychain on macOS 10.15+.
     @return YES if the password string was saved successfully.
  */
 + (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName
                              password:(NSString *)password
-               dataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
+            useDataProtectionKeychain:(BOOL)useDataProtectionKeychain API_AVAILABLE(macosx(10.15));
 
 /*! @brief Loads the password string from the keychain with the given identifier.
     @param keychainItemName Keychain name of the item.
@@ -55,12 +55,12 @@ NS_ASSUME_NONNULL_BEGIN
         choose to start using the data protection keychain on macOS, any items previously created
         will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
-    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
-        keychain on macOS 10.15+.
+    @param useDataProtectionKeychain A Boolean value that indicates whether to use the data
+        protection keychain on macOS 10.15+.
     @return The password string at the given identifier, or nil.
  */
 + (nullable NSString *)passwordFromKeychainForName:(NSString *)keychainItemName
-                            dataProtectionKeychain:(BOOL)dataProtectionKeychain
+                         useDataProtectionKeychain:(BOOL)useDataProtectionKeychain
     API_AVAILABLE(macosx(10.15));
 
 /*! @brief Saves the password data to the keychain with the given identifier.
@@ -76,13 +76,14 @@ NS_ASSUME_NONNULL_BEGIN
         will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
     @param passwordData Password data to save.
-    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
-        keychain on macOS 10.15+.
+    @param useDataProtectionKeychain A Boolean value that indicates whether to use the data
+        protection keychain on macOS 10.15+.
     @return YES if the password data was saved successfully.
  */
 + (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
                              passwordData:(NSData *)passwordData
-                   dataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
+                useDataProtectionKeychain:(BOOL)useDataProtectionKeychain
+    API_AVAILABLE(macosx(10.15));
 
 /*! @brief Loads the password data from the keychain with the given identifier.
     @param keychainItemName Keychain name of the item.
@@ -94,12 +95,12 @@ NS_ASSUME_NONNULL_BEGIN
         choose to start using the data protection keychain on macOS, any items previously created
         will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
-    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
-        keychain on macOS 10.15+.
+    @param useDataProtectionKeychain A Boolean value that indicates whether to use the data
+        protection keychain on macOS 10.15+.
     @return The password data at the given identifier, or nil.
  */
 + (nullable NSData *)passwordDataFromKeychainForName:(NSString *)keychainItemName
-                              dataProtectionKeychain:(BOOL)dataProtectionKeychain
+                           useDataProtectionKeychain:(BOOL)useDataProtectionKeychain
     API_AVAILABLE(macosx(10.15));
 
 /*! @brief Removes stored password string, such as when the user signs out.
@@ -112,12 +113,13 @@ NS_ASSUME_NONNULL_BEGIN
         choose to start using the data protection keychain on macOS, any items previously created
         will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
-    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
-        keychain on macOS 10.15+.
+    @param useDataProtectionKeychain A Boolean value that indicates whether to use the data
+        protection keychain on macOS 10.15+.
     @return YES if the password string was removed successfully (or didn't exist).
  */
 + (BOOL)removePasswordFromKeychainForName:(NSString *)keychainItemName
-                   dataProtectionKeychain:(BOOL)dataProtectionKeychain API_AVAILABLE(macosx(10.15));
+                useDataProtectionKeychain:(BOOL)useDataProtectionKeychain
+    API_AVAILABLE(macosx(10.15));
 
 @end
 

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
         will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
     @param password Password string to save.
-    @param dataProtectionKeychain Whether or not to use the data protection
+    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
         keychain on macOS 10.15+.
     @return YES if the password string was saved successfully.
  */
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
         choose to start using the data protection keychain on macOS, any items previously created
         will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
-    @param dataProtectionKeychain Whether or not to use the data protection
+    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
         keychain on macOS 10.15+.
     @return The password string at the given identifier, or nil.
  */
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
         will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
     @param passwordData Password data to save.
-    @param dataProtectionKeychain Whether or not to use the data protection
+    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
         keychain on macOS 10.15+.
     @return YES if the password data was saved successfully.
  */
@@ -94,7 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
         choose to start using the data protection keychain on macOS, any items previously created
         will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
-    @param dataProtectionKeychain Whether or not to use the data protection
+    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
         keychain on macOS 10.15+.
     @return The password data at the given identifier, or nil.
  */
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
         choose to start using the data protection keychain on macOS, any items previously created
         will not be accessible without migration.
     @param keychainItemName Keychain name of the item.
-    @param dataProtectionKeychain Whether or not to use the data protection
+    @param dataProtectionKeychain A Boolean value that indicates whether to use the data protection
         keychain on macOS 10.15+.
     @return YES if the password string was removed successfully (or didn't exist).
  */

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMKeychain.h
@@ -31,11 +31,31 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName password:(NSString *)password;
 
+/*! @brief Saves the password string to the keychain with the given identifier.
+    @param keychainItemName Keychain name of the item.
+    @param password Password string to save.
+    @param dataProtectionKeychain Whether or not to use the data protection
+        keychain on macOS 10.15+.
+    @return YES when the password string was saved successfully.
+ */
++ (BOOL)savePasswordToKeychainForName:(NSString *)keychainItemName
+                             password:(NSString *)password
+           withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
+
 /*! @brief Loads the password string from the keychain with the given identifier.
     @param keychainItemName Keychain name of the item.
     @return The password string at the given identifier, or nil.
  */
 + (nullable NSString *)passwordFromKeychainForName:(NSString *)keychainItemName;
+
+/*! @brief Loads the password string from the keychain with the given identifier.
+    @param keychainItemName Keychain name of the item.
+    @param dataProtectionKeychain Whether or not to use the data protection
+        keychain on macOS 10.15+.
+    @return The password string at the given identifier, or nil.
+ */
++ (nullable NSString *)passwordFromKeychainForName:(NSString *)keychainItemName
+                        withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
 
 /*! @brief Saves the password data to the keychain with the given identifier.
     @param keychainItemName Keychain name of the item.
@@ -45,17 +65,46 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
                              passwordData:(NSData *)passwordData;
 
+/*! @brief Saves the password data to the keychain with the given identifier.
+    @param keychainItemName Keychain name of the item.
+    @param passwordData Password data to save.
+    @param dataProtectionKeychain Whether or not to use the data protection
+        keychain on macOS 10.15+.
+    @return YES when the password data was saved successfully.
+ */
++ (BOOL)savePasswordDataToKeychainForName:(NSString *)keychainItemName
+                             passwordData:(NSData *)passwordData
+               withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
+
 /*! @brief Loads the password data from the keychain with the given identifier.
     @param keychainItemName Keychain name of the item.
     @return The password data at the given identifier, or nil.
  */
 + (nullable NSData *)passwordDataFromKeychainForName:(NSString *)keychainItemName;
 
+/*! @brief Loads the password data from the keychain with the given identifier.
+    @param keychainItemName Keychain name of the item.
+    @param dataProtectionKeychain Whether or not to use the data protection
+        keychain on macOS 10.15+.
+    @return The password data at the given identifier, or nil.
+ */
++ (nullable NSData *)passwordDataFromKeychainForName:(NSString *)keychainItemName
+                          withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
+
 /*! @brief Removes stored password string, such as when the user signs out.
     @param keychainItemName Keychain name of the item.
     @return YES if the password string was removed successfully (or didn't exist).
  */
 + (BOOL)removePasswordFromKeychainForName:(NSString *)keychainItemName;
+
+/*! @brief Removes stored password string, such as when the user signs out.
+    @param keychainItemName Keychain name of the item.
+    @param dataProtectionKeychain Whether or not to use the data protection
+        keychain on macOS 10.15+.
+    @return YES if the password string was removed successfully (or didn't exist).
+ */
++ (BOOL)removePasswordFromKeychainForName:(NSString *)keychainItemName
+               withDataProtectionKeychain:(BOOL)dataProtectionKeychain;
 
 @end
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ and this is encrypted and stored by
 For macOS, two Keychain storage options are available: the traditional file-based Keychain storage
 which uses access control lists and the more modern [data protection keychain storage](https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain?language=objc)
 which uses Keychain access control groups. By default, GTMAppAuth uses the file-based Keychain storage on macOS.  You may opt into using data protection keychain storage by using the parameter
-`withDataProtectionKeychain:YES` in your method calls.  Note that Keychain items stored via one
+`useDataProtectionKeychain:YES` in your method calls.  Note that Keychain items stored via one
 storage type will not be available via the other and macOS apps that choose to use the data
 protection Keychain will need to be signed in order for Keychain operations to succeed.
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,13 @@ representation of the relevant `GTMAppAuthFetcherAuthorization` instance is supp
 and this is encrypted and stored by
 [Keychain Services](https://developer.apple.com/documentation/security/keychain_services?language=objc).
 
+For macOS, two Keychain storage options are available: the traditional file-based Keychain storage
+which uses access control lists and the more modern [data protection keychain storage](https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain?language=objc)
+which uses Keychain access control groups. By default, GTMAppAuth uses the file-based Keychain storage on macOS.  You may opt into using data protection keychain storage by using the parameter
+`withDataProtectionKeychain:YES` in your method calls.  Note that Keychain items stored via one
+storage type will not be available via the other and macOS apps that choose to use the data
+protection Keychain will need to be signed in order for Keychain operations to succeed.
+
 #### GTMOAuth2 Compatibility
 
 To assist the migration from GTMOAuth2 to GTMAppAuth, GTMOAuth2-compatible


### PR DESCRIPTION
Give developers the option to use the [data protection keychain](https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain?language=objc) on macOS 10.15+.  When enabled, iOS-style Keychain storage will be used instead of the default file-based storage.  Using the data protection keychain on macOS will require that the app is signed in order for Keychain operations to succeed.