### PR TITLE
Add Swift library, target, and test target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - swift-translation
   pull_request:
     branches:
       - master
+      - swift-translation
   workflow_dispatch:
 
 jobs:
@@ -28,3 +30,5 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build package
       run: swift build
+    - name: Run Swift tests
+      run: swift test

--- a/GTMAppAuthSwift/Sources/GTMKeychain.swift
+++ b/GTMAppAuthSwift/Sources/GTMKeychain.swift
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Utility for saving and loading data to the keychain.
+@objc
+public class GTMKeychain: NSObject {
+
+}

--- a/GTMAppAuthSwift/Tests/GTMKeychainTests.swift
+++ b/GTMAppAuthSwift/Tests/GTMKeychainTests.swift
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+import GTMAppAuthSwift
+
+class GTMKeychainTests: XCTestCase {
+  func testKeychainInstance() {
+    let gtmKeychain = GTMKeychain()
+    XCTAssertNotNil(gtmKeychain)
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,10 @@ let package = Package(
         .library(
             name: "GTMAppAuth",
             targets: ["GTMAppAuth"]
+        ),
+        .library(
+            name: "GTMAppAuthSwift",
+            targets: ["GTMAppAuthSwift"]
         )
     ],
     dependencies: [
@@ -50,6 +54,22 @@ let package = Package(
 	    linkerSettings: [
                 .linkedFramework("Security"),
 	    ]
+        ),
+        .target(
+            name: "GTMAppAuthSwift",
+            dependencies: [
+                "GTMSessionFetcherCore",
+                "AppAuthCore"
+            ],
+            path: "GTMAppAuthSwift/Sources",
+	    linkerSettings: [
+                .linkedFramework("Security"),
+	    ]
+        ),
+        .testTarget(
+            name: "GTMAppAuthSwiftTests",
+            dependencies: ["GTMAppAuthSwift"],
+            path: "GTMAppAuthSwift/Tests"
         )
     ]
 )


### PR DESCRIPTION
This change establishes support for translating this library into Swift. It adds a Swift library to the package's list of products, an associated Swift target, and a Swift test target.