### PR TITLE
Ignore warnings from GTMFetcherAuthorizationProtocol deprecation

### DIFF
--- a/Examples/Example-iOS/Example-iOS.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS/Example-iOS.xcodeproj/project.pbxproj
@@ -378,7 +378,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/google/gtm-session-fetcher.git";
 			requirement = {
-				kind = upToNextMajorVersion;
+				kind = versionRange;
+				maximumVersion = 3.0.0;
 				minimumVersion = 1.0.0;
 			};
 		};

--- a/Examples/Example-iOS/Podfile
+++ b/Examples/Example-iOS/Podfile
@@ -11,5 +11,5 @@ target 'Example-iOSForPod' do
   # pod 'GTMAppAuth'
 
   pod 'AppAuth', '~> 1.0'
-  pod 'GTMSessionFetcher/Core', '~> 1.0'
+  pod 'GTMSessionFetcher/Core', '>= 1.0', '< 3.0'
 end

--- a/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.m
+++ b/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.m
@@ -22,9 +22,12 @@
 
 @import AppAuth;
 @import GTMAppAuth;
-#if __has_include("GTMSessionFetcher/GTMSessionFetcher.h") // Cocoapods
-@import GTMSessionFetcher;
-#else // SPM
+// CocoaPods || SPM && GTMSessionFetcher >= 2.0
+#if __has_include("GTMSessionFetcher/GTMSessionFetcher.h")
+#import <GTMSessionFetcher/GTMSessionFetcher.h>
+#import <GTMSessionFetcher/GTMSessionFetcherService.h>
+// SPM && GTMSessionFetcher < 2.0
+#else
 @import GTMSessionFetcherCore;
 #endif
 

--- a/Examples/Example-macOS/Example-macOS.xcodeproj/project.pbxproj
+++ b/Examples/Example-macOS/Example-macOS.xcodeproj/project.pbxproj
@@ -359,7 +359,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/google/gtm-session-fetcher.git";
 			requirement = {
-				kind = upToNextMajorVersion;
+				kind = versionRange;
+				maximumVersion = 3.0.0;
 				minimumVersion = 1.0.0;
 			};
 		};

--- a/Examples/Example-macOS/Podfile
+++ b/Examples/Example-macOS/Podfile
@@ -11,5 +11,5 @@ target 'Example-macOSForPod' do
   # pod 'GTMAppAuth'
 
   pod 'AppAuth', '~> 1.5'
-  pod 'GTMSessionFetcher/Core', '~> 1.0'
+  pod 'GTMSessionFetcher/Core', '>= 1.0', '< 3.0'
 end

--- a/Examples/Example-macOS/Source/GTMAppAuthExampleViewController.m
+++ b/Examples/Example-macOS/Source/GTMAppAuthExampleViewController.m
@@ -22,9 +22,12 @@
 
 @import AppAuth;
 @import GTMAppAuth;
-#if __has_include("GTMSessionFetcher/GTMSessionFetcher.h") // Cocoapods
-@import GTMSessionFetcher;
-#else // SPM
+// CocoaPods || SPM && GTMSessionFetcher >= 2.0
+#if __has_include("GTMSessionFetcher/GTMSessionFetcher.h")
+#import <GTMSessionFetcher/GTMSessionFetcher.h>
+#import <GTMSessionFetcher/GTMSessionFetcherService.h>
+// SPM && GTMSessionFetcher < 2.0
+#else
 @import GTMSessionFetcherCore;
 #endif
 

--- a/GTMAppAuth/Sources/GTMAppAuthFetcherAuthorization.m
+++ b/GTMAppAuth/Sources/GTMAppAuthFetcherAuthorization.m
@@ -355,9 +355,12 @@ NSString *const GTMAppAuthFetcherAuthorizationErrorRequestKey = @"request";
                        request:(NSMutableURLRequest *)request
              finishedWithError:(NSError *)error;
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)authorizeRequest:(NSMutableURLRequest *)request
                 delegate:(id)delegate
        didFinishSelector:(SEL)sel {
+#pragma clang diagnostic pop
   GTMOAuth2AssertValidSelector(delegate, sel,
                                @encode(GTMAppAuthFetcherAuthorization *),
                                @encode(NSMutableURLRequest *),

--- a/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization.h
+++ b/GTMAppAuth/Sources/Public/GTMAppAuth/GTMAppAuthFetcherAuthorization.h
@@ -71,8 +71,11 @@ typedef void (^GTMAppAuthFetcherAuthorizationCompletion)(NSError *_Nullable erro
         library.
     @discussion Enables you to use AppAuth with the GTM Session Fetcher library.
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 @interface GTMAppAuthFetcherAuthorization : NSObject <GTMFetcherAuthorizationProtocol,
                                                       NSSecureCoding>
+#pragma clang diagnostic pop
 
 /*! @brief The AppAuth authentication state.
  */


### PR DESCRIPTION
Building on #155 to accommodate GTMSessionFetcher 2.1 without generating warnings stemming from the [deprecation of `GTMFetcherAuthorizationProtocol`](https://github.com/google/gtm-session-fetcher/pull/315).