### PR TITLE
Run tests on `macOS-11`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   pod-lib-lint:
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
     - uses: actions/checkout@v2
     - name: Update Bundler
@@ -23,7 +23,7 @@ jobs:
       run: pod lib lint --verbose
 
   spm-build-test:
-    runs-on: macOS-latest
+    runs-on: macOS-11
     steps:
     - uses: actions/checkout@v2
     - name: Build package


### PR DESCRIPTION
The `macOS-latest` runner alias has changed from `macOS-11` to `macOS-12`.  Under the `macOS-12` runner the watchOS build for `pod lib lint` is failing for reasons that are unclear.  Temporarily revert to running on `macOS-11` until we diagnose.