### PR TITLE
Update iOS min version to provide GTMSessionFetcher 3 compatibility

### DIFF
--- a/GTMAppAuth.podspec
+++ b/GTMAppAuth.podspec
@@ -23,7 +23,7 @@ requests with AppAuth.
   s.public_header_files = "GTMAppAuth/Sources/Public/GTMAppAuth/*.h"
   s.requires_arc = true
 
-  s.ios.deployment_target = "9.0"
+  s.ios.deployment_target = "10.0"
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '6.0'

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     name: "GTMAppAuth",
     platforms: [
         .macOS(.v10_12),
-        .iOS(.v9),
+        .iOS(.v10),
         .tvOS(.v9),
         .watchOS(.v6)
     ],


### PR DESCRIPTION
In order to allow compatibility with GTMSessionFetcher 3+ we will increase our iOS min version from 9 to 10.