### PR TITLE
Update GTMAppAuthFetcherAuthorization.swift to use explicit @objc name

### DIFF
--- a/Examples/Example-iOS/Podfile
+++ b/Examples/Example-iOS/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 target 'Example-iOSForPod' do
   use_frameworks!

--- a/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.m
+++ b/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.m
@@ -126,7 +126,7 @@ static NSString *const kExampleAuthorizerKey = @"authorization";
 - (void)loadState {
   NSError *error;
   GTMAppAuthFetcherAuthorization *authorization =
-  [GTMAppAuthFetcherAuthorization authorizationForItemName:kExampleAuthorizerKey error:&error];
+      [GTMAppAuthFetcherAuthorization authorizationForItemName:kExampleAuthorizerKey error:&error];
   if (error) {
     NSLog(@"Error loading state: %@", error);
   }

--- a/GTMAppAuthSwift/Sources/GTMAppAuthFetcherAuthorization.swift
+++ b/GTMAppAuthSwift/Sources/GTMAppAuthFetcherAuthorization.swift
@@ -28,9 +28,10 @@ import GTMSessionFetcher
 /// An implementation of the `GTMFetcherAuthorizationProtocol` protocol for the AppAuth library.
 ///
 /// Enables you to use AppAuth with the GTM Session Fetcher library.
-@objc open class GTMAppAuthFetcherAuthorization: NSObject,
-                                                 GTMFetcherAuthorizationProtocol,
-                                                 NSSecureCoding {
+@objc(GTMAppAuthFetcherAuthorization)
+open class GTMAppAuthFetcherAuthorization: NSObject,
+                                           GTMFetcherAuthorizationProtocol,
+                                           NSSecureCoding {
   // MARK: - Retrieving Authorizations
 
   /// Internally scoped helper for used for setting the keychain to a fake in tests.


### PR DESCRIPTION
Using this explicit name forces the fully qualified Swift name for this type to match the Objective-C name.