### PR TITLE
Use `NSKeyedUnarchiver.setClass(_:forClassName:)` to migrate previous archives

### DIFF
--- a/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.h
+++ b/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.h
@@ -18,7 +18,7 @@
 #import <UIKit/UIKit.h>
 
 @class OIDAuthState;
-@class GTMAppAuthFetcherAuthorization;
+@class GTMAuthState;
 @class OIDServiceConfiguration;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*! @brief The authorization state.
  */
-@property(nonatomic, nullable) GTMAppAuthFetcherAuthorization *authorization;
+@property(nonatomic, nullable) GTMAuthState *authorization;
 
 /*! @brief Authorization code flow using @c OIDAuthState automatic code exchanges.
     @param sender IBAction sender.

--- a/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.m
+++ b/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.m
@@ -108,7 +108,7 @@ static NSString *const kExampleAuthorizerKey = @"authorization";
   [self updateUI];
 }
 
-/*! @brief Saves the @c GTMAppAuthFetcherAuthorization to @c NSUSerDefaults.
+/*! @brief Saves the @c GTMAuthState to @c NSUSerDefaults.
  */
 - (void)saveState {
   NSError *error;
@@ -122,11 +122,11 @@ static NSString *const kExampleAuthorizerKey = @"authorization";
   }
 }
 
-/*! @brief Loads the @c GTMAppAuthFetcherAuthorization from @c NSUSerDefaults.
+/*! @brief Loads the @c GTMAuthState from @c NSUSerDefaults.
  */
 - (void)loadState {
   NSError *error;
-  GTMAppAuthFetcherAuthorization *authorization =
+  GTMAuthState *authorization =
       [self.keychainStore retrieveAuthStateAndReturnError:&error];
   if (error) {
     NSLog(@"Error loading state: %@", error);
@@ -134,7 +134,7 @@ static NSString *const kExampleAuthorizerKey = @"authorization";
   [self setGtmAuthorization:authorization];
 }
 
-- (void)setGtmAuthorization:(GTMAppAuthFetcherAuthorization*)authorization {
+- (void)setGtmAuthorization:(GTMAuthState*)authorization {
   if ([_authorization isEqual:authorization]) {
     return;
   }
@@ -206,8 +206,7 @@ static NSString *const kExampleAuthorizerKey = @"authorization";
                             callback:^(OIDAuthState *_Nullable authState,
                                        NSError *_Nullable error) {
       if (authState) {
-        GTMAppAuthFetcherAuthorization *authorization =
-          [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:authState];
+        GTMAuthState *authorization = [[GTMAuthState alloc] initWithAuthState:authState];
 
         [self setGtmAuthorization:authorization];
         [self logMessage:@"Got authorization tokens. Access token: %@",

--- a/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.m
+++ b/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.m
@@ -39,7 +39,7 @@ static NSString *const kIssuer = @"https://accounts.google.com";
         https://console.developers.google.com/apis/credentials?project=_
         The client should be registered with the "iOS" type.
  */
-static NSString *const kClientID = @"687389107077-8qr6dh8fr4uaja89sdr5ieqb7mep04qv.apps.googleusercontent.com";
+static NSString *const kClientID = @"YOUR_CLIENT.apps.googleusercontent.com";
 
 /*! @brief The OAuth redirect URI for the client @c kClientID.
     @discussion With Google, the scheme of the redirect URI is the reverse DNS notation of the
@@ -48,7 +48,7 @@ static NSString *const kClientID = @"687389107077-8qr6dh8fr4uaja89sdr5ieqb7mep04
         'oauthredirect' here to help disambiguate from any other use of this scheme.
  */
 static NSString *const kRedirectURI =
-    @"com.googleusercontent.apps.687389107077-8qr6dh8fr4uaja89sdr5ieqb7mep04qv:/oauthredirect";
+    @"com.googleusercontent.apps.YOUR_CLIENT:/oauthredirect";
 
 /*! @brief @c NSCoding key for the authState property.
  */

--- a/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.m
+++ b/Examples/Example-iOS/Source/GTMAppAuthExampleViewController.m
@@ -39,7 +39,7 @@ static NSString *const kIssuer = @"https://accounts.google.com";
         https://console.developers.google.com/apis/credentials?project=_
         The client should be registered with the "iOS" type.
  */
-static NSString *const kClientID = @"YOUR_CLIENT.apps.googleusercontent.com";
+static NSString *const kClientID = @"687389107077-8qr6dh8fr4uaja89sdr5ieqb7mep04qv.apps.googleusercontent.com";
 
 /*! @brief The OAuth redirect URI for the client @c kClientID.
     @discussion With Google, the scheme of the redirect URI is the reverse DNS notation of the
@@ -48,7 +48,7 @@ static NSString *const kClientID = @"YOUR_CLIENT.apps.googleusercontent.com";
         'oauthredirect' here to help disambiguate from any other use of this scheme.
  */
 static NSString *const kRedirectURI =
-    @"com.googleusercontent.apps.YOUR_CLIENT:/oauthredirect";
+    @"com.googleusercontent.apps.687389107077-8qr6dh8fr4uaja89sdr5ieqb7mep04qv:/oauthredirect";
 
 /*! @brief @c NSCoding key for the authState property.
  */

--- a/Examples/Example-iOS/Source/Info.plist
+++ b/Examples/Example-iOS/Source/Info.plist
@@ -25,7 +25,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.687389107077-8qr6dh8fr4uaja89sdr5ieqb7mep04qv</string>
+				<string>com.googleusercontent.apps.YOUR_CLIENT</string>
 			</array>
 		</dict>
 	</array>

--- a/Examples/Example-iOS/Source/Info.plist
+++ b/Examples/Example-iOS/Source/Info.plist
@@ -25,7 +25,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.YOUR_CLIENT</string>
+				<string>com.googleusercontent.apps.687389107077-8qr6dh8fr4uaja89sdr5ieqb7mep04qv</string>
 			</array>
 		</dict>
 	</array>

--- a/GTMAppAuthSwift/Sources/AuthState.swift
+++ b/GTMAppAuthSwift/Sources/AuthState.swift
@@ -30,6 +30,9 @@ import GTMSessionFetcher
 /// Enables you to use AppAuth with the GTM Session Fetcher library.
 @objc(GTMAuthState)
 open class AuthState: NSObject, GTMFetcherAuthorizationProtocol, NSSecureCoding {
+  /// The legacy name for this type used while archiving and unarchiving an instance.
+  static let legacyArchiveName = "GTMAppAuthFetcherAuthorization"
+
   /// The AppAuth authentication state.
   @objc public let authState: OIDAuthState
 

--- a/GTMAppAuthSwift/Sources/AuthState.swift
+++ b/GTMAppAuthSwift/Sources/AuthState.swift
@@ -28,7 +28,7 @@ import GTMSessionFetcher
 /// An implementation of the `GTMFetcherAuthorizationProtocol` protocol for the AppAuth library.
 ///
 /// Enables you to use AppAuth with the GTM Session Fetcher library.
-@objc(GTMAppAuthFetcherAuthorization)
+@objc(GTMAuthState)
 open class AuthState: NSObject, GTMFetcherAuthorizationProtocol, NSSecureCoding {
   /// The AppAuth authentication state.
   @objc public let authState: OIDAuthState

--- a/GTMAppAuthSwift/Sources/KeychainStore.swift
+++ b/GTMAppAuthSwift/Sources/KeychainStore.swift
@@ -80,24 +80,7 @@ public final class KeychainStore: NSObject {
     self.keychainAttributes = keychainAttributes
     self.keychainHelper = keychainHelper
 
-    NSKeyedUnarchiver.setClass(AuthState.self, forClassName: "GTMAppAuthFetcherAuthorization")
     super.init()
-  }
-
-  @available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
-  private func modernUnarchiveAuthorization(
-    withPasswordData passwordData: Data,
-    itemName: String
-  ) throws -> AuthState {
-    guard let authorization = try NSKeyedUnarchiver.unarchivedObject(
-            ofClass: AuthState.self,
-            from: passwordData
-          ) else {
-      throw AuthState
-        .Error
-        .failedToConvertKeychainDataToAuthorization(forItemName: itemName)
-    }
-    return authorization
   }
 }
 
@@ -133,20 +116,21 @@ extension KeychainStore: AuthStateStore {
   private func authorizationData(
     fromAuthorization authState: AuthState
   ) throws -> Data {
-    let authorizationData: Data
-    if #available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *) {
-      do {
-        authorizationData = try NSKeyedArchiver.archivedData(
-          withRootObject: authState,
-          requiringSecureCoding: true
-        )
-      } catch {
-        throw KeychainStore.Error.failedToConvertAuthorizationToData
-      }
+    let keyedArchiver: NSKeyedArchiver
+    if #available(iOS 11, macOS 10.13, tvOS 11.0, watchOS 4.0, *) {
+      keyedArchiver = NSKeyedArchiver(requiringSecureCoding: true)
     } else {
-      authorizationData = NSKeyedArchiver.archivedData(withRootObject: authState)
+      keyedArchiver = NSKeyedArchiver()
     }
-    return authorizationData
+
+    // The previous name for `AuthState` was `GTMAppAuthFetcherAuthorization`. To allow legacy
+    // versions of this library to unarchive and archive instances of `AuthState` from new versions
+    // of this library, we will archive `AuthState` using the legacy name.
+    keyedArchiver.setClassName(AuthState.legacyArchiveName, for: AuthState.self)
+
+    keyedArchiver.encode(authState, forKey: NSKeyedArchiveRootObjectKey)
+    keyedArchiver.finishEncoding()
+    return keyedArchiver.encodedData
   }
 
   @objc public func removeAuthState(withItemName itemName: String) throws {
@@ -157,37 +141,49 @@ extension KeychainStore: AuthStateStore {
     try keychainHelper.removePassword(forService: itemName)
   }
 
+  private func keyedUnarchiver(forData data: Data) throws -> NSKeyedUnarchiver {
+    let keyedUnarchiver: NSKeyedUnarchiver
+    if #available(iOS 11.0, macOS 10.13, watchOS 4.0, tvOS 11.0, *) {
+      keyedUnarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+    } else {
+      keyedUnarchiver = NSKeyedUnarchiver(forReadingWith: data)
+    }
+    keyedUnarchiver.requiresSecureCoding = false
+    // The previous name for `AuthState` was `GTMAppAuthFetcherAuthorization` and so unarchiving
+    // requires mapping the name previous instances were archived under to the new name.
+    keyedUnarchiver.setClass(AuthState.self, forClassName: AuthState.legacyArchiveName)
+
+    return keyedUnarchiver
+  }
+
   @objc public func retrieveAuthState(forItemName itemName: String) throws -> AuthState {
     let passwordData = try keychainHelper.passwordData(forService: itemName)
 
-    if #available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *) {
-      return try modernUnarchiveAuthorization(withPasswordData: passwordData, itemName: itemName)
-    } else {
-      guard let auth = NSKeyedUnarchiver.unarchiveObject(with: passwordData) as? AuthState else {
-        throw AuthState
-          .Error
-          .failedToConvertKeychainDataToAuthorization(forItemName: itemName)
-      }
-      return auth
+    let keyedUnarchiver = try keyedUnarchiver(forData: passwordData)
+    guard let auth = keyedUnarchiver.decodeObject(
+      of: AuthState.self,
+      forKey: NSKeyedArchiveRootObjectKey
+    ) else {
+      throw AuthState
+        .Error
+        .failedToConvertKeychainDataToAuthorization(forItemName: itemName)
     }
+    return auth
   }
 
   @objc public func retrieveAuthState() throws -> AuthState {
     let passwordData = try keychainHelper.passwordData(forService: itemName)
 
-    if #available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *) {
-      return try modernUnarchiveAuthorization(
-        withPasswordData: passwordData,
-        itemName: itemName
-      )
-    } else {
-      guard let auth = NSKeyedUnarchiver.unarchiveObject(with: passwordData) as? AuthState else {
-        throw AuthState
-          .Error
-          .failedToConvertKeychainDataToAuthorization(forItemName: itemName)
-      }
-      return auth
+    let keyedUnarchiver = try keyedUnarchiver(forData: passwordData)
+    guard let auth = keyedUnarchiver.decodeObject(
+      of: AuthState.self,
+      forKey: NSKeyedArchiveRootObjectKey
+    ) else {
+      throw AuthState
+        .Error
+        .failedToConvertKeychainDataToAuthorization(forItemName: itemName)
     }
+    return auth
   }
 
   /// Attempts to create an `AuthState` from stored data in GTMOAuth2 format.

--- a/GTMAppAuthSwift/Sources/KeychainStore.swift
+++ b/GTMAppAuthSwift/Sources/KeychainStore.swift
@@ -79,6 +79,8 @@ public final class KeychainStore: NSObject {
     self.itemName = itemName
     self.keychainAttributes = keychainAttributes
     self.keychainHelper = keychainHelper
+
+    NSKeyedUnarchiver.setClass(AuthState.self, forClassName: "GTMAppAuthFetcherAuthorization")
     super.init()
   }
 

--- a/GTMAppAuthSwift/Tests/Helpers/KeychainHelperFake.swift
+++ b/GTMAppAuthSwift/Tests/Helpers/KeychainHelperFake.swift
@@ -24,6 +24,10 @@ public class KeychainHelperFake: NSObject, KeychainHelper {
   @objc public let accountName = "OauthTest"
   @objc public let keychainAttributes: Set<KeychainAttribute>
   @objc public var generatedKeychainQuery: [String: Any]?
+  /// Data generated from `NSKeyedArchiver` treated as a property list to test class name mapping.
+  private(set) var archiveDataPropertyList: Any?
+  /// Data generated from `NSKeyedUnarchiver` treated as a property list to test class name mapping.
+  private(set) var unarchiveDataPropertyList: Any?
 
   @objc public required init(keychainAttributes: Set<KeychainAttribute>) {
     self.keychainAttributes = keychainAttributes
@@ -65,6 +69,13 @@ public class KeychainHelperFake: NSObject, KeychainHelper {
     guard let passwordData = passwordStore[service + accountName] else {
       throw KeychainStore.Error.passwordNotFound(forItemName: service)
     }
+
+    // Use `try?` instead of try to avoid throwing in the ObjC integration tests and test failures
+    self.unarchiveDataPropertyList = try? PropertyListSerialization.propertyList(
+      from: passwordData,
+      format: nil
+    )
+
     return passwordData
   }
 
@@ -102,6 +113,12 @@ public class KeychainHelperFake: NSObject, KeychainHelper {
     accessibility: CFTypeRef?
   ) throws {
     guard !service.isEmpty else { throw KeychainStore.Error.noService }
+
+    // Use `try?` instead of try to avoid throwing in the ObjC integration tests and test failures
+    self.archiveDataPropertyList = try? PropertyListSerialization.propertyList(
+      from: data,
+      format: nil
+    )
     generatedKeychainQuery = keychainQuery(forService: service)
     passwordStore.updateValue(data, forKey: service + accountName)
   }

--- a/GTMAppAuthSwift/Tests/ObjCIntegration/GTMAuthStateTests.m
+++ b/GTMAppAuthSwift/Tests/ObjCIntegration/GTMAuthStateTests.m
@@ -40,14 +40,14 @@
 }
 
 - (void)testInitWithOIDAuthState {
-  GTMAppAuthFetcherAuthorization *authorization =
-  [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:[OIDAuthState testInstance]];
+  GTMAuthState *authorization =
+  [[GTMAuthState alloc] initWithAuthState:[OIDAuthState testInstance]];
   XCTAssertNotNil(authorization);
 }
 
 - (void)testDesignatedInitializer {
-  GTMAppAuthFetcherAuthorization *authorization =
-  [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:OIDAuthState.testInstance
+  GTMAuthState *authorization =
+  [[GTMAuthState alloc] initWithAuthState:OIDAuthState.testInstance
                                             serviceProvider:GTMTestingConstants.testServiceProvider
                                                      userID:GTMTestingConstants.testUserID
                                                   userEmail:GTMTestingConstants.testEmail
@@ -62,10 +62,10 @@
 
 - (void)testAuthorizeSecureRequestWithCompletion {
   XCTestExpectation *authRequestExpectation =
-  [[XCTestExpectation alloc] initWithDescription:@"Authorize with completion"];
+      [[XCTestExpectation alloc] initWithDescription:@"Authorize with completion"];
 
-  GTMAppAuthFetcherAuthorization *authorization =
-  [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:OIDAuthState.testInstance];
+  GTMAuthState *authorization =
+      [[GTMAuthState alloc] initWithAuthState:OIDAuthState.testInstance];
   NSMutableURLRequest *secureRequest = [NSMutableURLRequest requestWithURL:self.secureURL];
 
   [authorization authorizeRequest:secureRequest completionHandler:^(NSError * _Nullable error) {
@@ -80,17 +80,17 @@
 
 - (void)testAuthorizeSecureRequestWithDelegate {
   XCTestExpectation *delegateExpectation =
-  [[XCTestExpectation alloc] initWithDescription:@"Authorize with delegate"];
+      [[XCTestExpectation alloc] initWithDescription:@"Authorize with delegate"];
 
-  GTMAppAuthFetcherAuthorization *authorization =
-  [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:OIDAuthState.testInstance];
+  GTMAuthState *authorization =
+      [[GTMAuthState alloc] initWithAuthState:OIDAuthState.testInstance];
   NSMutableURLRequest *secureRequest = [NSMutableURLRequest requestWithURL:self.secureURL];
 
   OIDAuthState *authState = OIDAuthState.testInstance;
   GTMAuthorizationTestingHelper *originalAuthorization =
-  [[GTMAuthorizationTestingHelper alloc] initWithAuthState:authState];
+      [[GTMAuthorizationTestingHelper alloc] initWithAuthState:authState];
   GTMAuthorizationTestDelegate *testingDelegate =
-  [[GTMAuthorizationTestDelegate alloc] initWithExpectation:delegateExpectation];
+      [[GTMAuthorizationTestDelegate alloc] initWithExpectation:delegateExpectation];
 
   NSMutableURLRequest *originalRequest = [[NSMutableURLRequest alloc] initWithURL:self.secureURL];
   [originalAuthorization authorizeRequest:originalRequest
@@ -108,10 +108,10 @@
 
 - (void)testStopAuthorization {
   XCTestExpectation *authorizeSecureRequestExpectation =
-  [self expectationWithDescription:@"Authorize with completion expectation"];
+      [self expectationWithDescription:@"Authorize with completion expectation"];
 
-  GTMAppAuthFetcherAuthorization *authorization =
-      [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:OIDAuthState.testInstance];
+  GTMAuthState *authorization =
+      [[GTMAuthState alloc] initWithAuthState:OIDAuthState.testInstance];
   NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:self.secureURL];
 
   [authorization authorizeRequest:request completionHandler:^(NSError * _Nullable error) {
@@ -130,8 +130,8 @@
   XCTestExpectation *authorizeSecureRequestExpectation =
   [self expectationWithDescription:@"Authorize with completion expectation"];
 
-  GTMAppAuthFetcherAuthorization *authorization =
-      [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:OIDAuthState.testInstance];
+  GTMAuthState *authorization =
+      [[GTMAuthState alloc] initWithAuthState:OIDAuthState.testInstance];
   NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:self.secureURL];
 
   [authorization authorizeRequest:request completionHandler:^(NSError * _Nullable error) {
@@ -147,15 +147,15 @@
 }
 
 - (void)testIsAuthorizedRequest {
-  GTMAppAuthFetcherAuthorization *authorization =
-      [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:OIDAuthState.testInstance];
+  GTMAuthState *authorization =
+      [[GTMAuthState alloc] initWithAuthState:OIDAuthState.testInstance];
   NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:self.secureURL];
   XCTAssertFalse([authorization isAuthorizedRequest:request]);
 }
 
 - (void)testCanAuthorizeRequest {
-  GTMAppAuthFetcherAuthorization *authorization =
-      [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:OIDAuthState.testInstance];
+  GTMAuthState *authorization =
+      [[GTMAuthState alloc] initWithAuthState:OIDAuthState.testInstance];
   XCTAssertTrue([authorization canAuthorize]);
 }
 
@@ -164,14 +164,14 @@
       [OIDAuthState testInstanceWithAuthorizationResponse:nil
                                             tokenResponse:nil
                                      registrationResponse:OIDRegistrationResponse.testInstance];
-  GTMAppAuthFetcherAuthorization *authorization =
-      [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:testAuthState];
+  GTMAuthState *authorization =
+      [[GTMAuthState alloc] initWithAuthState:testAuthState];
   XCTAssertFalse([authorization canAuthorize]);
 }
 
 - (void)testIsNotPrimeForRefresh {
-  GTMAppAuthFetcherAuthorization *authorization =
-      [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:OIDAuthState.testInstance];
+  GTMAuthState *authorization =
+      [[GTMAuthState alloc] initWithAuthState:OIDAuthState.testInstance];
   XCTAssertFalse([authorization primeForRefresh]);
 }
 
@@ -180,13 +180,13 @@
       [OIDAuthState testInstanceWithAuthorizationResponse:nil
                                             tokenResponse:nil
                                      registrationResponse:OIDRegistrationResponse.testInstance];
-  GTMAppAuthFetcherAuthorization *authorization =
-      [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:testAuthState];
+  GTMAuthState *authorization =
+      [[GTMAuthState alloc] initWithAuthState:testAuthState];
   XCTAssertTrue([authorization primeForRefresh]);
 }
 
 - (void)testConfigurationForGoogle {
-  OIDServiceConfiguration *configuration = [GTMAppAuthFetcherAuthorization configurationForGoogle];
+  OIDServiceConfiguration *configuration = [GTMAuthState configurationForGoogle];
   XCTAssertNotNil(configuration);
   XCTAssertEqualObjects(configuration.authorizationEndpoint, self.googleAuthzEndpoint);
   XCTAssertEqualObjects(configuration.tokenEndpoint, self.tokenEndpoint);

--- a/GTMAppAuthSwift/Tests/ObjCIntegration/GTMKeychainStoreTests.m
+++ b/GTMAppAuthSwift/Tests/ObjCIntegration/GTMKeychainStoreTests.m
@@ -22,7 +22,7 @@
 
 @interface GTMKeychainStoreTests : XCTestCase
 
-@property (nonatomic) GTMAppAuthFetcherAuthorization *authorization;
+@property (nonatomic) GTMAuthState *authorization;
 @property (nonatomic) GTMKeychainStore *keychainStore;
 
 @end
@@ -31,7 +31,7 @@
 
 - (void)setUp {
   self.authorization =
-      [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:[OIDAuthState testInstance]];
+      [[GTMAuthState alloc] initWithAuthState:[OIDAuthState testInstance]];
 
   NSSet *emptyKeychainAttributes = [NSSet set];
   GTMKeychainHelperFake *fakeKeychain =
@@ -92,7 +92,7 @@
   XCTAssertNil(error);
 
   XCTAssertEqualObjects(newItemName, self.keychainStore.itemName);
-  GTMAppAuthFetcherAuthorization *retrievedAuth =
+  GTMAuthState *retrievedAuth =
       [self.keychainStore retrieveAuthStateForItemName:self.keychainStore.itemName error:&error];
   XCTAssertNotNil(retrievedAuth);
 
@@ -113,7 +113,7 @@
                                   error:&error];
   XCTAssertNil(error);
 
-  GTMAppAuthFetcherAuthorization *retrievedAuth =
+  GTMAuthState *retrievedAuth =
   [self.keychainStore retrieveAuthStateForItemName:customItemName error:&error];
   XCTAssertNotNil(retrievedAuth);
   XCTAssertNil(error);
@@ -143,7 +143,7 @@
   [self.keychainStore saveWithAuthState:self.authorization error:&error];
   XCTAssertNil(error);
 
-  GTMAppAuthFetcherAuthorization *testAuthorization =
+  GTMAuthState *testAuthorization =
       [self.keychainStore retrieveAuthStateAndReturnError:&error];
   XCTAssertNil(error);
 
@@ -159,7 +159,7 @@
 - (void)testRetrieveAuthorizationForMissingItemName {
   NSError *error;
   NSString *missingItemName = @"missingItemName";
-  GTMAppAuthFetcherAuthorization *missingAuth =
+  GTMAuthState *missingAuth =
       [self.keychainStore retrieveAuthStateForItemName:missingItemName error:&error];
 
   XCTAssertNil(missingAuth);
@@ -174,7 +174,7 @@
   [self.keychainStore saveWithAuthState:self.authorization forItemName:customItemName error:&error];
   XCTAssertNil(error);
 
-  GTMAppAuthFetcherAuthorization *retrievedAuth =
+  GTMAuthState *retrievedAuth =
       [self.keychainStore retrieveAuthStateAndReturnError:&error];
   XCTAssertNotNil(retrievedAuth);
   XCTAssertNotNil(retrievedAuth);
@@ -233,8 +233,8 @@
 
 - (void)testRetrieveAuthStateInGTMOAuth2Format {
   NSError *error;
-  GTMAppAuthFetcherAuthorization *expectedAuthorization =
-      [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:[OIDAuthState testInstance]
+  GTMAuthState *expectedAuthorization =
+      [[GTMAuthState alloc] initWithAuthState:[OIDAuthState testInstance]
                                                 serviceProvider:[GTMTestingConstants testServiceProvider]
                                                          userID:[GTMTestingConstants testUserID]
                                                       userEmail:[GTMTestingConstants testEmail]
@@ -243,7 +243,7 @@
                                                         error:&error];
   XCTAssertNil(error);
 
-  GTMAppAuthFetcherAuthorization *testAuth =
+  GTMAuthState *testAuth =
       [self.keychainStore retrieveAuthStateInGTMOAuth2FormatWithTokenURL:[GTMTestingConstants testTokenURL]
                                                              redirectURI:[GTMTestingConstants testRedirectURI]
                                                                 clientID:[GTMTestingConstants testClientID]

--- a/GTMAppAuthSwift/Tests/ObjCIntegration/GTMOAuth2KeychainCompatibilityTests.m
+++ b/GTMAppAuthSwift/Tests/ObjCIntegration/GTMOAuth2KeychainCompatibilityTests.m
@@ -22,7 +22,7 @@
 
 @interface GTMOAuth2KeychainCompatibilityTests : XCTestCase
 
-@property (nonatomic) GTMAppAuthFetcherAuthorization *expectedAuthorization;
+@property (nonatomic) GTMAuthState *expectedAuthorization;
 
 @end
 
@@ -30,7 +30,7 @@
 
 - (void)setUp {
   self.expectedAuthorization =
-      [[GTMAppAuthFetcherAuthorization alloc] initWithAuthState:OIDAuthState.testInstance
+      [[GTMAuthState alloc] initWithAuthState:OIDAuthState.testInstance
                                                 serviceProvider:GTMTestingConstants.testServiceProvider
                                                          userID:GTMTestingConstants.userID
                                                       userEmail:GTMTestingConstants.testEmail
@@ -52,7 +52,7 @@
 - (void)testAuthStateForPersistenceString {
   NSError *error;
   GTMOAuth2KeychainCompatibility *oauth2Compat = [[GTMOAuth2KeychainCompatibility alloc] init];
-  GTMAppAuthFetcherAuthorization *testPersistAuth =
+  GTMAuthState *testPersistAuth =
       [oauth2Compat authStateForPersistenceString:[self expectedPersistenceResponseString]
                                          tokenURL:GTMTestingConstants.testTokenURL
                                       redirectURI:GTMTestingConstants.testRedirectURI
@@ -79,7 +79,7 @@
 - (void)testAuthStateForPersistenceStringThrows {
   NSError *error;
   GTMOAuth2KeychainCompatibility *oauth2Compat = [[GTMOAuth2KeychainCompatibility alloc] init];
-  GTMAppAuthFetcherAuthorization *testPersistAuth =
+  GTMAuthState *testPersistAuth =
       [oauth2Compat authStateForPersistenceString:[self expectedPersistenceResponseString]
                                          tokenURL:GTMTestingConstants.testTokenURL
                                       redirectURI:@""

--- a/GTMAppAuthSwift/Tests/Unit/AuthStateTests.swift
+++ b/GTMAppAuthSwift/Tests/Unit/AuthStateTests.swift
@@ -331,9 +331,9 @@ class AuthStateTests: XCTestCase {
     }
   }
 
-  func testReadAuthorization() throws {
-    try keychainStore.save(authState: authState, forItemName: TestingConstants.testKeychainItemName)
-    let savedAuth = try keychainStore.retrieveAuthState(forItemName: TestingConstants.testKeychainItemName)
+  func testRetrieveAuthorization() throws {
+    try keychainStore.save(authState: authState)
+    let savedAuth = try keychainStore.retrieveAuthState()
     XCTAssertEqual(savedAuth.authState.isAuthorized, authState.authState.isAuthorized)
     XCTAssertEqual(savedAuth.serviceProvider, authState.serviceProvider)
     XCTAssertEqual(savedAuth.userID, authState.userID)
@@ -342,7 +342,20 @@ class AuthStateTests: XCTestCase {
     XCTAssertFalse(keychainHelper.useDataProtectionKeychain)
   }
 
-  func testReadAuthorizationThrowsError() {
+  func testRetrieveAuthorizationForItemName() throws {
+    try keychainStore.save(authState: authState, forItemName: alternativeTestKeychainItemName)
+    let retrievedAuth = try keychainStore.retrieveAuthState(
+      forItemName: alternativeTestKeychainItemName
+    )
+    XCTAssertEqual(retrievedAuth.authState.isAuthorized, authState.authState.isAuthorized)
+    XCTAssertEqual(retrievedAuth.serviceProvider, authState.serviceProvider)
+    XCTAssertEqual(retrievedAuth.userID, authState.userID)
+    XCTAssertEqual(retrievedAuth.userEmail, authState.userEmail)
+    XCTAssertEqual(retrievedAuth.userEmailIsVerified, authState.userEmailIsVerified)
+    XCTAssertFalse(keychainHelper.useDataProtectionKeychain)
+  }
+
+  func testRetrieveAuthorizationForMissingNameThrowsError() {
     let missingItemName = "missingItemName"
     do {
       _ = try keychainStore.retrieveAuthState(forItemName: missingItemName)


### PR DESCRIPTION
Previous usage of GTMAppAuth would potentially lead to instances of `GTMAppAuthFetcherAuthorization` being archived. Since we have renamed this type, and also changed the API considerably, we need to migrate the name to use in unarchiving via `NSKeyedUnarchiver.setClass(_:forClassName:)` so that instances previously archived can be unarchived into the renamed instance (`GTMAuthState`).

I tested archiving and unarchiving in the example app. I also tested backwards and forwards compatibility with a local branch pinned to [tag 2.0.0](https://github.com/google/GTMAppAuth/releases/tag/2.0.0). 

First, I checked out the example from tag 2.0.0 and authenticated. I then switched branches to this branch and tried to start up the example app. I was successfully able to unarchive the instance archived with the older version of the library.

Second, I reset the simulator app to start fresh. I checked out this branch, authenticated, and archived that instance. I then checked out the branch at tag 2.0.0. I build the sample app and was able to successfully unarchive the instance created from the newer version of the library.