### PR TITLE
Do not import @testable target in non-test target

### DIFF
--- a/GTMAppAuth/Sources/KeychainStore/KeychainAttribute.swift
+++ b/GTMAppAuth/Sources/KeychainStore/KeychainAttribute.swift
@@ -18,11 +18,11 @@ import Foundation
 
 @objc(GTMKeychainAttribute)
 public final class KeychainAttribute: NSObject {
-  enum Attribute {
+  public enum Attribute {
     case useDataProtectionKeychain
     case accessGroup(String)
 
-    var keyName: String {
+    public var keyName: String {
       switch self {
       case .useDataProtectionKeychain:
         return "kSecUseDataProtectionKeychain"
@@ -32,9 +32,9 @@ public final class KeychainAttribute: NSObject {
     }
   }
 
-  let attribute: Attribute
+  public let attribute: Attribute
 
-  init(attribute: Attribute) {
+  public init(attribute: Attribute) {
     self.attribute = attribute
   }
 

--- a/GTMAppAuth/Tests/Helpers/AuthorizationTestingHelp.swift
+++ b/GTMAppAuth/Tests/Helpers/AuthorizationTestingHelp.swift
@@ -23,7 +23,7 @@ import AppAuthCore
 import AppAuth
 #endif
 import XCTest
-@testable import GTMAppAuth
+import GTMAppAuth
 
 /// A subclass of `AuthSession` to use in tests.
 @objc(GTMAuthorizationTestingHelper)

--- a/GTMAppAuth/Tests/Helpers/KeychainHelperFake.swift
+++ b/GTMAppAuth/Tests/Helpers/KeychainHelperFake.swift
@@ -15,7 +15,7 @@
  */
 
 import Foundation
-@testable import GTMAppAuth
+import GTMAppAuth
 
 @objc(GTMKeychainHelperFake)
 public class KeychainHelperFake: NSObject, KeychainHelper {


### PR DESCRIPTION
The [nightly build workflow was failing](https://github.com/google/GTMAppAuth/actions/runs/3764133576/jobs/6398259647) due to an `@testable import GTMAppAuth` in `AuthorizationTestingHelp.swift`. This import caused the build failure because this testing helper was not located within a testing target, and so `@testable` should not be used.

The [build workflow is now passing](https://github.com/google/GTMAppAuth/actions/runs/3767451451) with this PR's changes.