### PR TITLE
Move unused error from AuthSession to KeychainStore

### DIFF
--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -454,16 +454,15 @@ public extension AuthSession {
   enum Error: Swift.Error, Equatable, CustomNSError {
     case cannotAuthorizeRequest(URLRequest)
     case accessTokenEmptyForRequest(URLRequest)
-    case failedToConvertKeychainDataToAuthSession(forItemName: String)
+
     public static let errorDomain: String = "GTMAuthSessionErrorDomain"
+
     public var errorUserInfo: [String : Any] {
       switch self {
       case .cannotAuthorizeRequest(let request):
         return ["request": request]
       case .accessTokenEmptyForRequest(let request):
         return ["request": request]
-      case .failedToConvertKeychainDataToAuthSession(forItemName: let name):
-        return ["itemName": name]
       }
     }
   }

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -181,9 +181,9 @@ open class AuthSession: NSObject, GTMFetcherAuthorizationProtocol, NSSecureCodin
   ///   - handler: The block that is called after authorizing the request is attempted.  If `error`
   ///     is non-nil, the authorization failed.  Errors in the domain `OIDOAuthTokenErrorDomain`
   ///     indicate that the authorization itself is invalid, and will need to be re-obtained from
-  ///     the user.  `KeychainStore.Error` and `AuthSession.Error` indicate other unrecoverable
-  ///     errors.  Errors in other domains may indicate a transitive error condition such as a
-  ///     network error, and typically you do not need to reauthenticate the user on such errors.
+  ///     the user.  `AuthSession.Error`s indicate other unrecoverable errors. Errors in other
+  ///     domains may indicate a transitive error condition such as a network error, and typically
+  ///     you do not need to reauthenticate the user on such errors.
   ///
   /// The completion handler is scheduled on the main thread, unless the `callbackQueue` property is
   /// set on the `fetcherService` in which case the handler is scheduled on that queue.
@@ -450,7 +450,7 @@ public extension AuthSession {
 
   // MARK: - Errors
 
-  /// Errors that may arise while authorizing a request or saving a request to the keychain.
+  /// Errors that may arise while authorizing a request.
   enum Error: Swift.Error, Equatable, CustomNSError {
     case cannotAuthorizeRequest(URLRequest)
     case accessTokenEmptyForRequest(URLRequest)

--- a/GTMAppAuth/Sources/KeychainStore/KeychainStore.swift
+++ b/GTMAppAuth/Sources/KeychainStore/KeychainStore.swift
@@ -173,9 +173,7 @@ extension KeychainStore: AuthSessionStore {
       of: AuthSession.self,
       forKey: NSKeyedArchiveRootObjectKey
     ) else {
-      throw AuthSession
-        .Error
-        .failedToConvertKeychainDataToAuthSession(forItemName: itemName)
+      throw Error.failedToConvertKeychainDataToAuthSession(itemName: itemName)
     }
     return auth
   }
@@ -188,9 +186,7 @@ extension KeychainStore: AuthSessionStore {
       of: AuthSession.self,
       forKey: NSKeyedArchiveRootObjectKey
     ) else {
-      throw AuthSession
-        .Error
-        .failedToConvertKeychainDataToAuthSession(forItemName: itemName)
+      throw Error.failedToConvertKeychainDataToAuthSession(itemName: itemName)
     }
     return auth
   }
@@ -275,6 +271,7 @@ public extension KeychainStore {
     case failedToCreateResponseStringFromAuthSession(AuthSession)
     case failedToConvertRedirectURItoURL(String)
     case failedToConvertAuthSessionToData
+    case failedToConvertKeychainDataToAuthSession(itemName: String)
     case failedToDeletePassword(forItemName: String)
     case failedToDeletePasswordBecauseItemNotFound(itemName: String)
     case failedToSetPassword(forItemName: String)
@@ -299,6 +296,8 @@ public extension KeychainStore {
         return ["redirectURI": redirectURI]
       case .failedToConvertAuthSessionToData:
         return [:]
+      case .failedToConvertKeychainDataToAuthSession(itemName: let itemName):
+        return ["itemName": itemName]
       case .failedToDeletePassword(let itemName):
         return ["itemName": itemName]
       case .failedToDeletePasswordBecauseItemNotFound(itemName: let itemName):
@@ -324,6 +323,7 @@ public enum ErrorCode: Int {
   case failedToCreateResponseStringFromAuthSession
   case failedToConvertRedirectURItoURL
   case failedToConvertAuthSessionToData
+  case failedToConvertKeychainDataToAuthSession
   case failedToDeletePassword
   case failedToDeletePasswordBecauseItemNotFound
   case failedToSetPassword
@@ -344,6 +344,8 @@ public enum ErrorCode: Int {
       self = .failedToConvertRedirectURItoURL
     case .failedToConvertAuthSessionToData:
       self = .failedToConvertAuthSessionToData
+    case .failedToConvertKeychainDataToAuthSession:
+      self = .failedToConvertKeychainDataToAuthSession
     case .failedToDeletePassword:
       self = .failedToDeletePassword
     case .failedToDeletePasswordBecauseItemNotFound:

--- a/GTMAppAuth/Tests/Unit/KeychainStore/KeychainStoreTests.swift
+++ b/GTMAppAuth/Tests/Unit/KeychainStore/KeychainStoreTests.swift
@@ -370,7 +370,7 @@ class KeychainStoreTests: XCTestCase {
     XCTAssertEqual(testAccessGroupName, expectedGroupName)
   }
 
-  func testSaveAndReadAuthSession() throws {
+  func testSaveAndRetrieveAuthSession() throws {
     try keychainStore.save(authSession: authSession)
     let expectedAuthSession = try keychainStore.retrieveAuthSession()
     XCTAssertEqual(
@@ -383,7 +383,7 @@ class KeychainStoreTests: XCTestCase {
     XCTAssertEqual(expectedAuthSession.userEmailIsVerified, authSession.userEmailIsVerified)
   }
 
-  func testReadAuthSessionWithItemNameGivenToKeychain() throws {
+  func testRetrieveAuthSessionWithItemNameGivenToKeychain() throws {
     try keychainStore.save(authSession: authSession)
     let expectedAuthSession = try keychainStore.retrieveAuthSession()
     XCTAssertEqual(
@@ -396,7 +396,7 @@ class KeychainStoreTests: XCTestCase {
     XCTAssertEqual(expectedAuthSession.userEmailIsVerified, authSession.userEmailIsVerified)
   }
 
-  func testReadAuthSessionForItemName() throws {
+  func testRetrieveAuthSessionForItemName() throws {
     let anotherItemName = "anotherItemName"
     try keychainStore.save(authSession: authSession, forItemName: anotherItemName)
     let expectedAuthSession = try keychainStore.retrieveAuthSession(forItemName: anotherItemName)
@@ -409,6 +409,14 @@ class KeychainStoreTests: XCTestCase {
     XCTAssertEqual(expectedAuthSession.userID, authSession.userID)
     XCTAssertEqual(expectedAuthSession.userEmail, authSession.userEmail)
     XCTAssertEqual(expectedAuthSession.userEmailIsVerified, authSession.userEmailIsVerified)
+  }
+
+  func testRetrievePasswordNoService() throws {
+    try keychainStore.save(authSession: authSession)
+
+    XCTAssertThrowsError(try keychainStore.retrieveAuthSession(forItemName: "")) { thrownError in
+      XCTAssertEqual(thrownError as? KeychainStore.Error, .noService)
+    }
   }
 
   func testSaveAuthSessionForItemName() throws {
@@ -425,18 +433,10 @@ class KeychainStoreTests: XCTestCase {
     XCTAssertEqual(expectedAuthSession.userEmailIsVerified, authSession.userEmailIsVerified)
   }
 
-  func testSetPasswordNoService() {
+  func testSavePasswordNoService() {
     XCTAssertThrowsError(
       try keychainStore.save(authSession: authSession, forItemName: "")
     ) { thrownError in
-      XCTAssertEqual(thrownError as? KeychainStore.Error, .noService)
-    }
-  }
-
-  func testReadPasswordNoService() throws {
-    try keychainStore.save(authSession: authSession)
-
-    XCTAssertThrowsError(try keychainStore.retrieveAuthSession(forItemName: "")) { thrownError in
       XCTAssertEqual(thrownError as? KeychainStore.Error, .noService)
     }
   }


### PR DESCRIPTION
This PR moves `.failedToConvertKeychainDataToAuthSession` from `AuthSession.Error` to `KeychainStore.Error`, uses it in the latter, and also renames some tests in `KeychainStoreTests` to better match method names.