### PR TITLE
Use GTMSessionFetcherAuthorizer instead of GTMFetcherAuthorizationProtocol

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       run: bundle install
     - name: Lint GTMAppAuth.podspec using local source
       # Allow warnings until we transition to GTMSessionFetcherAuthorizer
-      run: pod lib lint GTMAppAuth.podspec --allow-warnings --verbose
+      run: pod lib lint GTMAppAuth.podspec --verbose
 
   spm-build-test:
     runs-on: macOS-11

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       run: bundle install
     - name: Lint GTMAppAuth.podspec using local source
       # Allow warnings until we transition to GTMSessionFetcherAuthorizer
-      run: pod lib lint GTMAppAuth.podspec --verbose --allow-warnings
+      run: pod lib lint GTMAppAuth.podspec --verbose
 
   spm-build-test:
     runs-on: macOS-11

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       run: bundle install
     - name: Lint GTMAppAuth.podspec using local source
       # Allow warnings until we transition to GTMSessionFetcherAuthorizer
-      run: pod lib lint GTMAppAuth.podspec --verbose
+      run: pod lib lint GTMAppAuth.podspec --verbose --allow-warnings
 
   spm-build-test:
     runs-on: macOS-11

--- a/GTMAppAuth.podspec
+++ b/GTMAppAuth.podspec
@@ -32,7 +32,7 @@ requests with AppAuth.
   s.watchos.deployment_target = watchos_deployment_target
 
   s.framework = 'Security'
-  s.dependency 'GTMSessionFetcher/Core', '>= 1.5', '< 4.0'
+  s.dependency 'GTMSessionFetcher/Core', '>= 2.1', '< 4.0'
   s.dependency 'AppAuth/Core', '~> 1.6'
 
   s.test_spec 'unit' do |unit_tests|

--- a/GTMAppAuth.podspec
+++ b/GTMAppAuth.podspec
@@ -60,7 +60,7 @@ requests with AppAuth.
       'GTMAppAuth/Tests/ObjCIntegration/**/*.m',
       'GTMAppAuth/Tests/Helpers/**/*.swift',
     ]
-    api_tests.dependency 'AppAuth'
+    api_tests.dependency 'AppAuth/Core'
     # api_tests.dependency 'GTMAppAuth/TestHelpers'
   end
 

--- a/GTMAppAuth.podspec
+++ b/GTMAppAuth.podspec
@@ -61,7 +61,6 @@ requests with AppAuth.
       'GTMAppAuth/Tests/Helpers/**/*.swift',
     ]
     api_tests.dependency 'AppAuth/Core'
-    # api_tests.dependency 'GTMAppAuth/TestHelpers'
   end
 
 end

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -29,7 +29,7 @@ import GTMSessionFetcher
 ///
 /// Enables you to use AppAuth with the GTM Session Fetcher library.
 @objc(GTMAuthSession)
-open class AuthSession: NSObject, GTMFetcherAuthorizationProtocol, NSSecureCoding {
+open class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureCoding {
   /// The legacy name for this type used while archiving and unarchiving an instance.
   static let legacyArchiveName = "GTMAppAuthFetcherAuthorization"
 
@@ -171,7 +171,7 @@ open class AuthSession: NSObject, GTMFetcherAuthorizationProtocol, NSSecureCodin
     )
   }
 
-  // MARK: - Authorizing Requests (GTMFetcherAuthorizationProtocol)
+  // MARK: - Authorizing Requests (GTMSessionFetcherAuthorizer)
 
   /// Adds an authorization header to the given request, using the authorization state. Refreshes
   /// the access token if needed.
@@ -206,7 +206,7 @@ open class AuthSession: NSObject, GTMFetcherAuthorizationProtocol, NSSecureCodin
   /// - Parameters:
   ///   - request: The request to authorize.
   ///   - delegate: The delegate to receive the callback.
-  ///   - sel: The `Selector` to call upon the provided `delegate`.
+  ///   - selector: The `Selector` to call upon the provided `delegate`.
   @objc(authorizeRequest:delegate:didFinishSelector:)
   public func authorizeRequest(
     _ request: NSMutableURLRequest?,

--- a/GTMAppAuth/Sources/KeychainStore/GTMOAuth2Compatibility.swift
+++ b/GTMAppAuth/Sources/KeychainStore/GTMOAuth2Compatibility.swift
@@ -128,7 +128,17 @@ public final class GTMOAuth2Compatibility: NSObject {
     let passwordDictionary = Dictionary(uniqueKeysWithValues: keyValueTuples)
     return passwordDictionary
   }
-  
+
+  /// Creates an `AuthSession` from the provided persistence string.
+  /// - Parameters:
+  ///   - persistenceString: The `String` representing the `AuthState` to create.
+  ///   - tokenURL: The `URL` to use when creating the `AuthState`.
+  ///   - redirectURI: The `String` URI to use for the `AuthState`.
+  ///   - clientID: The `String` client ID for the `AuthState`.
+  ///   - clientSecret: The optional `String` for the `AuthState`.
+  /// - Throws: `KeychainStore.Error.failedToConvertRedirectURItoURL` if `redirectURI` cannot be
+  ///   converted to a `URL`.
+  /// - Returns: An instance of `AuthState` if successful.
   @objc public func authSession(
     forPersistenceString persistenceString: String,
     tokenURL: URL,

--- a/GTMAppAuth/Sources/KeychainStore/GTMOAuth2Compatibility.swift
+++ b/GTMAppAuth/Sources/KeychainStore/GTMOAuth2Compatibility.swift
@@ -131,14 +131,14 @@ public final class GTMOAuth2Compatibility: NSObject {
 
   /// Creates an `AuthSession` from the provided persistence string.
   /// - Parameters:
-  ///   - persistenceString: The `String` representing the `AuthState` to create.
-  ///   - tokenURL: The `URL` to use when creating the `AuthState`.
-  ///   - redirectURI: The `String` URI to use for the `AuthState`.
-  ///   - clientID: The `String` client ID for the `AuthState`.
-  ///   - clientSecret: The optional `String` for the `AuthState`.
+  ///   - persistenceString: The `String` representing the `AuthSession` to create.
+  ///   - tokenURL: The `URL` to use when creating the `AuthSession`.
+  ///   - redirectURI: The `String` URI to use for the `AuthSession`.
+  ///   - clientID: The `String` client ID for the `AuthSession`.
+  ///   - clientSecret: The optional `String` for the `AuthSession`.
   /// - Throws: `KeychainStore.Error.failedToConvertRedirectURItoURL` if `redirectURI` cannot be
   ///   converted to a `URL`.
-  /// - Returns: An instance of `AuthState` if successful.
+  /// - Returns: An instance of `AuthSession` if successful.
   @objc public func authSession(
     forPersistenceString persistenceString: String,
     tokenURL: URL,

--- a/GTMAppAuth/Tests/Helpers/OIDTokenResponseTesting.swift
+++ b/GTMAppAuth/Tests/Helpers/OIDTokenResponseTesting.swift
@@ -53,15 +53,15 @@ import AppAuth
     expires: NSNumber?,
     tokenRequest: OIDTokenRequest?
   ) -> Self {
-    let parameters = [
-      "access_token": accessToken ?? TestingConstants.testAccessToken,
-      "expires_in": expires ?? TestingConstants.accessTokenExpiresIn as NSNumber,
-      "token_type": "example_token_type",
-      "refresh_token": TestingConstants.testRefreshToken,
-      "scope": OIDScopeUtilities.scopes(with: [TestingConstants.testScope2]),
-      "server_code": TestingConstants.serverAuthCode,
-      "id_token": idToken
-    ] as! [String : NSCopying & NSObjectProtocol]
+    let parameters: [String: NSObject & NSCopying] = [
+      "access_token": (accessToken ?? TestingConstants.testAccessToken) as NSString,
+      "expires_in": (expires ?? NSNumber(value: TestingConstants.accessTokenExpiresIn)),
+      "token_type": "example_token_type" as NSString,
+      "refresh_token": TestingConstants.testRefreshToken as NSString,
+      "scope": OIDScopeUtilities.scopes(with: [TestingConstants.testScope2]) as NSString,
+      "server_code": TestingConstants.serverAuthCode as NSString,
+      "id_token": idToken as NSString
+    ]
 
     return OIDTokenResponse(
       request: tokenRequest ?? OIDTokenRequest.testInstance(),

--- a/GTMAppAuth/Tests/ObjCIntegration/KeychainStore/GTMOAuth2CompatibilityTests.m
+++ b/GTMAppAuth/Tests/ObjCIntegration/KeychainStore/GTMOAuth2CompatibilityTests.m
@@ -84,7 +84,8 @@
 - (void)testAuthSessionForPersistenceStringThrows {
   NSError *error;
   GTMOAuth2Compatibility *gtmOAuth2Compat = [[GTMOAuth2Compatibility alloc] init];
-  GTMAuthSession *testPersistAuthSession =
+
+  GTMAuthSession *testPersistAuthSession __unused =
       [gtmOAuth2Compat authSessionForPersistenceString:[self expectedPersistenceResponseString]
                                               tokenURL:GTMTestingConstants.testTokenURL
                                            redirectURI:@""

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/google/gtm-session-fetcher.git", "1.5.0" ..< "4.0.0"),
+    .package(url: "https://github.com/google/gtm-session-fetcher.git", "2.1.0" ..< "4.0.0"),
     .package(url: "https://github.com/openid/AppAuth-iOS.git", "1.6.0" ..< "2.0.0")
   ],
   targets: [


### PR DESCRIPTION
https://github.com/google/gtm-session-fetcher/pull/315 deprecates `GTMFetcherAuthorizationProtocol` in favor of the newer `GTMSessionFetcherAuthorizer`. The protocols are functionally the same, but invert the required and optional methods. This change helps Swift conformers avoid implementing a selector-based callback, which is awkward. In any case, we retain that conformance as well for convenience.

Additionally, this change allow us to no longer ignore warning while `pod lib lint`ing and require us to bump our dependency on `gtm-session-fetcher` to 2.1.0.