### PR TITLE
Publish DocC generated documentation via Pages

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
   generate:
     runs-on: macos-12
     steps:
@@ -43,19 +44,15 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: /tmp/docs
-            
-    
+
   deploy:
     needs: generate
-    
     permissions:
       pages: write
       id-token: write
-
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
Add an Action that uses [DocC](https://developer.apple.com/documentation/docc) to generate API documentation from source comments and then [deploys](https://github.com/actions/deploy-pages) it to [GitHub Pages](https://pages.github.com/).

https://google.github.io/GTMAppAuth/
