### PR TITLE
Add AuthSession.ErrorCode and tests to ensure code export to ObjC

### DIFF
--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -465,5 +465,28 @@ public extension AuthSession {
         return ["request": request]
       }
     }
+
+    public var errorCode: Int {
+      return ErrorCode(error: self).rawValue
+    }
+  }
+
+  /// Error codes associated with cases from `AuthSession.Error`.
+  ///
+  /// The cases for this enumeration are backed by integer raw values and are used to fill out the
+  /// `errorCode` for the `NSError` representation of `AuthSession.Error`.
+  @objc(GTMAuthSessionErrorCode)
+  enum ErrorCode: Int {
+    case cannotAuthorizeRequest
+    case accessTokenEmptyForRequest
+
+    init(error: AuthSession.Error) {
+      switch error {
+      case .cannotAuthorizeRequest:
+        self = .cannotAuthorizeRequest
+      case .accessTokenEmptyForRequest:
+        self = .accessTokenEmptyForRequest
+      }
+    }
   }
 }

--- a/GTMAppAuth/Tests/Helpers/OIDTokenResponseTesting.swift
+++ b/GTMAppAuth/Tests/Helpers/OIDTokenResponseTesting.swift
@@ -47,6 +47,47 @@ import AppAuth
     ) as! Self
   }
 
+  public static func testInstanceWithoutAccessToken(
+    idToken: String,
+    expires: NSNumber?,
+    tokenRequest: OIDTokenRequest?
+  ) -> Self {
+    let parameters: [String: NSObject & NSCopying] = [
+      "expires_in": (expires ?? NSNumber(value: TestingConstants.accessTokenExpiresIn)),
+      "token_type": "example_token_type" as NSString,
+      "refresh_token": TestingConstants.testRefreshToken as NSString,
+      "scope": OIDScopeUtilities.scopes(with: [TestingConstants.testScope2]) as NSString,
+      "server_code": TestingConstants.serverAuthCode as NSString,
+      "id_token": idToken as NSString
+    ]
+
+    return OIDTokenResponse(
+      request: tokenRequest ?? OIDTokenRequest.testInstance(),
+      parameters: parameters
+    ) as! Self
+  }
+
+  public static func testInstanceWithEmptyAccessToken(
+    idToken: String,
+    expires: NSNumber?,
+    tokenRequest: OIDTokenRequest?
+  ) -> Self {
+    let parameters: [String: NSObject & NSCopying] = [
+      "access_token": "" as NSString,
+      "expires_in": (expires ?? NSNumber(value: TestingConstants.accessTokenExpiresIn)),
+      "token_type": "example_token_type" as NSString,
+      "refresh_token": TestingConstants.testRefreshToken as NSString,
+      "scope": OIDScopeUtilities.scopes(with: [TestingConstants.testScope2]) as NSString,
+      "server_code": TestingConstants.serverAuthCode as NSString,
+      "id_token": idToken as NSString
+    ]
+
+    return OIDTokenResponse(
+      request: tokenRequest ?? OIDTokenRequest.testInstance(),
+      parameters: parameters
+    ) as! Self
+  }
+
   public static func testInstance(
     idToken: String,
     accessToken: String?,

--- a/GTMAppAuth/Tests/ObjCIntegration/GTMAuthSessionTests.m
+++ b/GTMAppAuth/Tests/ObjCIntegration/GTMAuthSessionTests.m
@@ -30,6 +30,7 @@
 @property (nonatomic) NSURL *googleAuthzEndpoint;
 @property (nonatomic) NSURL *tokenEndpoint;
 @property (nonatomic) NSURL *secureURL;
+@property (nonatomic) NSURL *insecureURL;
 @property (nonatomic) NSTimeInterval expectationTimeout;
 
 @end
@@ -38,6 +39,7 @@
 
 - (void)setUp {
   self.secureURL = [NSURL URLWithString:@"https://fake.com"];
+  self.insecureURL = [NSURL URLWithString:@"http://fake.com"];
   self.googleAuthzEndpoint = [NSURL URLWithString:@"https://accounts.google.com/o/oauth2/v2/auth"];
   self.tokenEndpoint = [NSURL URLWithString:@"https://www.googleapis.com/oauth2/v4/token"];
   self.expectationTimeout = 5;
@@ -81,6 +83,72 @@
   XCTAssertTrue([authSession isAuthorizingRequest:secureRequest]);
   [self waitForExpectations:@[authRequestExpectation] timeout:self.expectationTimeout];
   XCTAssertTrue([authSession isAuthorizedRequest:secureRequest]);
+}
+
+- (void)testAuthorizeSecureRequestWithCompletionEmptyAccessTokenError {
+  XCTestExpectation *authRequestExpectation =
+      [[XCTestExpectation alloc] initWithDescription:@"Authorize with completion"];
+
+  OIDTokenResponse *tokenResponse =
+      [OIDTokenResponse testInstanceWithEmptyAccessTokenWithIdToken:@""
+                                                            expires:nil
+                                                       tokenRequest:nil];
+  GTMAuthSession *authSession =
+      [[GTMAuthSession alloc] initWithAuthState:[OIDAuthState testInstanceWithTokenResponse:tokenResponse]];
+  NSMutableURLRequest *secureRequest = [NSMutableURLRequest requestWithURL:self.secureURL];
+
+  [authSession authorizeRequest:secureRequest completionHandler:^(NSError * _Nullable error) {
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, GTMAuthSessionErrorCodeAccessTokenEmptyForRequest);
+    [authRequestExpectation fulfill];
+  }];
+
+  XCTAssertTrue([authSession isAuthorizingRequest:secureRequest]);
+  [self waitForExpectations:@[authRequestExpectation] timeout:self.expectationTimeout];
+  XCTAssertFalse([authSession isAuthorizedRequest:secureRequest]);
+}
+
+- (void)testAuthorizeSecureRequestWithCompletionNilAccessTokenError {
+  XCTestExpectation *authRequestExpectation =
+      [[XCTestExpectation alloc] initWithDescription:@"Authorize with completion"];
+
+  OIDTokenResponse *tokenResponse =
+      [OIDTokenResponse testInstanceWithoutAccessTokenWithIdToken:@""
+                                                          expires:nil
+                                                     tokenRequest:nil];
+
+  GTMAuthSession *authSession =
+      [[GTMAuthSession alloc] initWithAuthState:[OIDAuthState testInstanceWithTokenResponse:tokenResponse]];
+  NSMutableURLRequest *secureRequest = [NSMutableURLRequest requestWithURL:self.secureURL];
+
+  [authSession authorizeRequest:secureRequest completionHandler:^(NSError * _Nullable error) {
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, GTMAuthSessionErrorCodeAccessTokenEmptyForRequest);
+    [authRequestExpectation fulfill];
+  }];
+
+  XCTAssertTrue([authSession isAuthorizingRequest:secureRequest]);
+  [self waitForExpectations:@[authRequestExpectation] timeout:self.expectationTimeout];
+  XCTAssertFalse([authSession isAuthorizedRequest:secureRequest]);
+}
+
+- (void)testAuthorizeInsecureRequestWithCompletionError {
+  XCTestExpectation *authRequestExpectation =
+      [[XCTestExpectation alloc] initWithDescription:@"Authorize with completion"];
+
+  GTMAuthSession *authSession =
+      [[GTMAuthSession alloc] initWithAuthState:[OIDAuthState testInstance]];
+  NSMutableURLRequest *secureRequest = [NSMutableURLRequest requestWithURL:self.insecureURL];
+
+  [authSession authorizeRequest:secureRequest completionHandler:^(NSError * _Nullable error) {
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, GTMAuthSessionErrorCodeCannotAuthorizeRequest);
+    [authRequestExpectation fulfill];
+  }];
+
+  XCTAssertTrue([authSession isAuthorizingRequest:secureRequest]);
+  [self waitForExpectations:@[authRequestExpectation] timeout:self.expectationTimeout];
+  XCTAssertFalse([authSession isAuthorizedRequest:secureRequest]);
 }
 
 - (void)testAuthorizeSecureRequestWithDelegate {
@@ -192,3 +260,4 @@
 }
 
 @end
+


### PR DESCRIPTION
Adds an enum mapping Swift's `AuthSession.Error` error cases to names that can be represented, and inspected, in ObjC. Also adds tests for these cases in the interop tests.