### PR TITLE
Move AuthSessionStore conformance into class declaration

### DIFF
--- a/GTMAppAuth/Sources/KeychainStore/KeychainStore.swift
+++ b/GTMAppAuth/Sources/KeychainStore/KeychainStore.swift
@@ -28,7 +28,7 @@ import GTMSessionFetcher
 
 /// A helper providing a concrete implementation for saving and loading auth data to the keychain.
 @objc(GTMKeychainStore)
-public final class KeychainStore: NSObject {
+public final class KeychainStore: NSObject, AuthSessionStore {
   private let keychainHelper: KeychainHelper
   /// The last used `NSKeyedArchiver` used in tests to ensure that the class name mapping worked.
   private(set) var lastUsedKeyedArchiver: NSKeyedArchiver?
@@ -86,11 +86,9 @@ public final class KeychainStore: NSObject {
 
     super.init()
   }
-}
 
-// MARK: - AuthSessionStore Conformance
+  // MARK: - AuthSessionStore Conformance
 
-extension KeychainStore: AuthSessionStore {
   /// An initializer for to create an instance of this keychain wrapper.
   ///
   /// - Parameters:


### PR DESCRIPTION
For some reason, [DocC](https://developer.apple.com/documentation/docc) is interpreting our existing extension-based conformance as a [default implementation](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html#ID529).  