### PR TITLE
Do not lint and run tests against watchOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install Ruby gems with Bundler
       run: bundle install
     - name: Lint GTMAppAuth.podspec using local source
-      run: pod lib lint GTMAppAuth.podspec --verbose --platforms=ios,tvos,macos
+      run: pod lib lint GTMAppAuth.podspec --verbose
 
   spm-build-test:
     runs-on: macOS-11

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,7 @@ jobs:
     - name: Install Ruby gems with Bundler
       run: bundle install
     - name: Lint GTMAppAuth.podspec using local source
-      # Allow warnings until we transition to GTMSessionFetcherAuthorizer
-      run: pod lib lint GTMAppAuth.podspec --verbose
+      run: pod lib lint GTMAppAuth.podspec --verbose --platforms=ios,tvos,macos
 
   spm-build-test:
     runs-on: macOS-11

--- a/GTMAppAuth.podspec
+++ b/GTMAppAuth.podspec
@@ -40,7 +40,6 @@ requests with AppAuth.
       :ios => ios_deployment_target,
       :osx => osx_deployment_target,
       :tvos => tvos_deployment_target,
-      :watchos => watchos_deployment_target,
     }
     unit_tests.source_files = [
       'GTMAppAuth/Tests/Unit/**/*.swift',
@@ -54,7 +53,6 @@ requests with AppAuth.
       :ios => ios_deployment_target,
       :osx => osx_deployment_target,
       :tvos => tvos_deployment_target,
-      :watchos => watchos_deployment_target,
     }
     api_tests.source_files = [
       'GTMAppAuth/Tests/ObjCIntegration/**/*.m',


### PR DESCRIPTION
Per [this CocoaPods bug](https://github.com/CocoaPods/CocoaPods/issues/11558) it seems like there is a problem with how CocoaPods finds and runs tests on watchOS. Excluding watchOS from the linted platforms should unblock us to move forward with https://github.com/google/GTMAppAuth/pull/224.