### PR TITLE
Add a method taking a completion argument for asynchronous error updates 

### DIFF
--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -186,9 +186,8 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
   ///     you do not need to reauthenticate the user on such errors.
   ///
   /// The completion handler is scheduled on unless the `callbackQueue` property set on the
-  /// `fetcherService`. If the `fetcherService` does not have a callbacak queue, then a global queue
-  /// with the quality of service specified as `userInitiated` is used since the callback may
-  /// provide UI with an updated error .
+  /// `fetcherService`. If the `fetcherService` does not have a callback queue, then a queue is
+  /// created.
   @objc(authorizeRequest:completionHandler:)
   public func authorizeRequest(
     _ request: NSMutableURLRequest?,
@@ -285,7 +284,8 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
     } else {
       args.error = Error.cannotAuthorizeRequest(request as URLRequest)
     }
-    let callbackQueue = fetcherService?.callbackQueue ?? DispatchQueue.global(qos: .userInteractive)
+    let qLabel = "com.google.gtmappauth.maybe_update_error"
+    let callbackQueue = fetcherService?.callbackQueue ?? DispatchQueue(label: qLabel)
 
     callbackQueue.async {
       if let error = args.error, let delegate = self.delegate {

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -286,9 +286,7 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
     let callbackQueue = fetcherService?.callbackQueue ?? DispatchQueue.main
 
     let callback: () -> Void = {
-      callbackQueue.async { [weak self] in
-        guard let self = self else { return }
-
+      callbackQueue.async {
         switch args.callbackStyle {
         case .completion(let callback):
           self.invokeCompletionCallback(with: callback, error: args.error)
@@ -303,9 +301,9 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
       }
     }
 
-    if let error = args.error, let delegate = self.delegate, delegate.updatedError != nil {
+    if let error = args.error, let delegate = self.delegate, delegate.updateError != nil {
       // Use updated error if exists; otherwise, use whatever is already in `args.error`
-      delegate.updatedError?(forAuthSession: self, originalError: error) { updatedError in
+      delegate.updateError?(forAuthSession: self, originalError: error) { updatedError in
         args.error = updatedError ?? error
         callback()
       }

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -285,7 +285,7 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
     }
     let callbackQueue = fetcherService?.callbackQueue ?? DispatchQueue(label: "com.google.GTMAppAuth.updateErrorQueue")
 
-    callbackQueue.async(flags: .barrier) {
+    callbackQueue.sync {
       if let error = args.error, let delegate = self.delegate {
         // Use updated error if exists; otherwise, use whatever is already in `args.error`
         delegate.updatedError?(forAuthSession: self, originalError: error) { updatedError in

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -304,7 +304,7 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
       }
     }
 
-    if let error = args.error, let delegate = self.delegate, delegate.updatedError != nil {
+    if let error = args.error, let delegate = self.delegate {
       // Use updated error if exists; otherwise, use whatever is already in `args.error`
       delegate.updatedError?(forAuthSession: self, originalError: error) { updatedError in
         args.error = updatedError ?? error

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -283,31 +283,19 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
     } else {
       args.error = Error.cannotAuthorizeRequest(request as URLRequest)
     }
-    let callbackQueue = fetcherService?.callbackQueue ?? DispatchQueue.main
+    let callbackQueue = fetcherService?.callbackQueue ?? DispatchQueue(label: "com.google.GTMAppAuth.updateErrorQueue")
 
-//    callbackQueue.async(flags: .barrier) {
-//      if let error = args.error, let delegate = self.delegate {
-//        // Use updated error if exists; otherwise, use whatever is already in `args.error`
-//        delegate.updatedError?(forAuthSession: self, originalError: error) { updatedError in
-//          args.error = updatedError ?? error
-//        }
-//      }
-//    }
-
-    callbackQueue.async { [weak self] in
-      guard let self = self else { return }
-
-      let errorSemaphore = DispatchSemaphore(value: 0)
+    callbackQueue.async(flags: .barrier) {
       if let error = args.error, let delegate = self.delegate {
         // Use updated error if exists; otherwise, use whatever is already in `args.error`
         delegate.updatedError?(forAuthSession: self, originalError: error) { updatedError in
           args.error = updatedError ?? error
-          errorSemaphore.signal()
         }
-      } else {
-        errorSemaphore.signal()
       }
-      _ = errorSemaphore.wait(timeout: .now() + 1)
+    }
+
+    callbackQueue.async { [weak self] in
+      guard let self = self else { return }
 
       switch args.callbackStyle {
       case .completion(let callback):

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -290,8 +290,9 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
 
       if let error = args.error, let delegate = self.delegate {
         // Use updated error if exists; otherwise, use whatever is already in `args.error`
-        let newError = delegate.updatedError?(forAuthSession: self, originalError: error)
-        args.error = newError ?? error
+        delegate.updatedError?(forAuthSession: self, originalError: error) { updatedError in
+          args.error = updatedError
+        }
       }
 
       switch args.callbackStyle {

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -303,7 +303,7 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
       }
     }
 
-    if let error = args.error, let delegate = self.delegate {
+    if let error = args.error, let delegate = self.delegate, delegate.updatedError != nil {
       // Use updated error if exists; otherwise, use whatever is already in `args.error`
       delegate.updatedError?(forAuthSession: self, originalError: error) { updatedError in
         args.error = updatedError ?? error

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -293,7 +293,7 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
           args.error = updatedError ?? error
           errorSemaphore.signal()
         }
-        _ = errorSemaphore.wait(timeout: .now() + 1)
+        errorSemaphore.wait()
       }
     }
 

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -285,18 +285,29 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
     }
     let callbackQueue = fetcherService?.callbackQueue ?? DispatchQueue.main
 
-    callbackQueue.async(flags: .barrier) {
-      if let error = args.error, let delegate = self.delegate {
-        // Use updated error if exists; otherwise, use whatever is already in `args.error`
-        delegate.updatedError?(forAuthSession: self, originalError: error) { updatedError in
-          args.error = updatedError ?? error
-        }
-      }
-    }
+//    callbackQueue.async(flags: .barrier) {
+//      if let error = args.error, let delegate = self.delegate {
+//        // Use updated error if exists; otherwise, use whatever is already in `args.error`
+//        delegate.updatedError?(forAuthSession: self, originalError: error) { updatedError in
+//          args.error = updatedError ?? error
+//        }
+//      }
+//    }
 
     callbackQueue.async { [weak self] in
       guard let self = self else { return }
 
+      let errorSemaphore = DispatchSemaphore(value: 0)
+      if let error = args.error, let delegate = self.delegate {
+        // Use updated error if exists; otherwise, use whatever is already in `args.error`
+        delegate.updatedError?(forAuthSession: self, originalError: error) { updatedError in
+          args.error = updatedError ?? error
+          errorSemaphore.signal()
+        }
+      } else {
+        errorSemaphore.signal()
+      }
+      _ = errorSemaphore.wait(timeout: .now() + 1)
 
       switch args.callbackStyle {
       case .completion(let callback):

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -185,9 +185,8 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
   ///     domains may indicate a transitive error condition such as a network error, and typically
   ///     you do not need to reauthenticate the user on such errors.
   ///
-  /// The completion handler is scheduled on unless the `callbackQueue` property set on the
-  /// `fetcherService`. If the `fetcherService` does not have a callback queue, then a queue is
-  /// created.
+  /// The completion handler is scheduled on the main thread, unless the `callbackQueue` property is
+  /// set on the `fetcherService` in which case the handler is scheduled on that queue.
   @objc(authorizeRequest:completionHandler:)
   public func authorizeRequest(
     _ request: NSMutableURLRequest?,

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -285,15 +285,18 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
     }
     let callbackQueue = fetcherService?.callbackQueue ?? DispatchQueue.main
 
-    callbackQueue.async { [weak self] in
-      guard let self = self else { return }
-
+    callbackQueue.sync {
       if let error = args.error, let delegate = self.delegate {
         // Use updated error if exists; otherwise, use whatever is already in `args.error`
         delegate.updatedError?(forAuthSession: self, originalError: error) { updatedError in
           args.error = updatedError
         }
       }
+    }
+
+    callbackQueue.async { [weak self] in
+      guard let self = self else { return }
+
 
       switch args.callbackStyle {
       case .completion(let callback):

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -285,11 +285,11 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
     }
     let callbackQueue = fetcherService?.callbackQueue ?? DispatchQueue.main
 
-    callbackQueue.sync {
+    callbackQueue.async(flags: .barrier) {
       if let error = args.error, let delegate = self.delegate {
         // Use updated error if exists; otherwise, use whatever is already in `args.error`
         delegate.updatedError?(forAuthSession: self, originalError: error) { updatedError in
-          args.error = updatedError
+          args.error = updatedError ?? error
         }
       }
     }

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -304,7 +304,7 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
       }
     }
 
-    if let error = args.error, let delegate = self.delegate {
+    if let error = args.error, let delegate = self.delegate, delegate.updatedError != nil {
       // Use updated error if exists; otherwise, use whatever is already in `args.error`
       delegate.updatedError?(forAuthSession: self, originalError: error) { updatedError in
         args.error = updatedError ?? error

--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -285,14 +285,14 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
     }
     let callbackQueue = fetcherService?.callbackQueue ?? DispatchQueue.main
 
-    if let error = args.error, let delegate = self.delegate {
-      // If there is an updated error, use that; otherwise, use whatever is already in `args.error`
-      let newError = delegate.updatedError?(forAuthSession: self, originalError: error)
-      args.error = newError ?? error
-    }
-
     callbackQueue.async { [weak self] in
       guard let self = self else { return }
+
+      if let error = args.error, let delegate = self.delegate {
+        // Use updated error if exists; otherwise, use whatever is already in `args.error`
+        let newError = delegate.updatedError?(forAuthSession: self, originalError: error)
+        args.error = newError ?? error
+      }
 
       switch args.callbackStyle {
       case .completion(let callback):

--- a/GTMAppAuth/Sources/AuthSessionDelegate.swift
+++ b/GTMAppAuth/Sources/AuthSessionDelegate.swift
@@ -31,20 +31,6 @@ public protocol AuthSessionDelegate {
   /// A method notifying the delegate that the authorization request failed.
   ///
   /// Use this method to examine the error behind the failed authorization request and supply a
-  /// customized error specifying whatever context is needed.
-  ///
-  /// - Parameters:
-  ///   - authSession: The `AuthSession` whose authorization request failed.
-  ///   - originalError: The original `Error` associated with the failure.
-  /// - Returns: The new error for `AuthSession` to send back or nil if no error should be sent.
-  @objc optional func updatedError(
-    forAuthSession authSession: AuthSession,
-    originalError: Error
-  ) -> Error?
-
-  /// A method notifying the delegate that the authorization request failed.
-  ///
-  /// Use this method to examine the error behind the failed authorization request and supply a
   /// customized error created asynchronously that specifies whatever context is needed.
   ///
   /// - Parameters:

--- a/GTMAppAuth/Sources/AuthSessionDelegate.swift
+++ b/GTMAppAuth/Sources/AuthSessionDelegate.swift
@@ -37,7 +37,7 @@ public protocol AuthSessionDelegate {
   ///   - authSession: The `AuthSession` whose authorization request failed.
   ///   - originalError: The original `Error` associated with the failure.
   ///   - completion: An escaping closure to pass back the updated error.
-  @objc optional func updatedError(
+  @objc optional func updateError(
     forAuthSession authSession: AuthSession,
     originalError: Error,
     completion: @escaping (Error?) -> Void

--- a/GTMAppAuth/Sources/AuthSessionDelegate.swift
+++ b/GTMAppAuth/Sources/AuthSessionDelegate.swift
@@ -30,8 +30,8 @@ public protocol AuthSessionDelegate {
 
   /// A method notifying the delegate that the authorization request failed.
   ///
-  /// Use this method to examine the error behind the failed authorization request and supply a more
-  /// custom error specifying whatever context is needed.
+  /// Use this method to examine the error behind the failed authorization request and supply a
+  /// customized error specifying whatever context is needed.
   ///
   /// - Parameters:
   ///   - authSession: The `AuthSession` whose authorization request failed.
@@ -41,4 +41,19 @@ public protocol AuthSessionDelegate {
     forAuthSession authSession: AuthSession,
     originalError: Error
   ) -> Error?
+
+  /// A method notifying the delegate that the authorization request failed.
+  ///
+  /// Use this method to examine the error behind the failed authorization request and supply a
+  /// customized error created asynchronously that specifies whatever context is needed.
+  ///
+  /// - Parameters:
+  ///   - authSession: The `AuthSession` whose authorization request failed.
+  ///   - originalError: The original `Error` associated with the failure.
+  ///   - completion: An escaping closure to pass back the updated error.
+  @objc optional func updatedError(
+    forAuthSession authSession: AuthSession,
+    originalError: Error,
+    completion: @escaping (Error?) -> Void
+  )
 }

--- a/GTMAppAuth/Tests/Helpers/AuthorizationTestingHelp.swift
+++ b/GTMAppAuth/Tests/Helpers/AuthorizationTestingHelp.swift
@@ -107,4 +107,14 @@ public class AuthSessionDelegateProvider: NSObject, AuthSessionDelegate {
     }
     return expectedError
   }
+
+  public func updatedError(
+    forAuthSession authSession: AuthSession,
+    originalError: Error,
+    completion: @escaping (Error?) -> Void
+  ) {
+    XCTAssertEqual(authSession, originalAuthSession)
+    updatedErrorCalled = true
+    completion(expectedError)
+  }
 }

--- a/GTMAppAuth/Tests/Helpers/AuthorizationTestingHelp.swift
+++ b/GTMAppAuth/Tests/Helpers/AuthorizationTestingHelp.swift
@@ -63,10 +63,42 @@ public class AuthorizationTestDelegate: NSObject {
   }
 }
 
+/// A testing helper that does not implement the update error method in `AuthSessionDelegate`.
+@objc(GTMAuthSessionDelegateProvideMissingEMMErrorHandling)
+public class AuthSessionDelegateProvideMissingEMMErrorHandling: NSObject, AuthSessionDelegate {
+  /// The `AuthSession` to which this delegate was given.
+  @objc public var originalAuthSession: AuthSession?
+
+  /// Whether or not the delegate callback for additional refresh parameters was called.
+  ///
+  /// - Note: Defaults to `false`.
+  @objc public var additionalRefreshParametersCalled = false
+
+  /// Whether or not the delegate callback for authorization request failure was called.
+  ///
+  /// - Note: Defaults to `false`.
+  @objc public var updatedErrorCalled = false
+
+  /// The expected error from the delegate callback.
+  @objc public let expectedError: NSError?
+
+  @objc public init(originalAuthSession: AuthSession, expectedError: NSError? = nil) {
+    self.originalAuthSession = originalAuthSession
+    self.expectedError = expectedError
+  }
+
+  public func additionalTokenRefreshParameters(
+    forAuthSession authSession: AuthSession
+  ) -> [String : String]? {
+    XCTAssertEqual(authSession, originalAuthSession)
+    additionalRefreshParametersCalled = true
+    return [:]
+  }
+}
+
 /// A testing helper given to `AuthSession`'s `delegate` to verify delegate callbacks.
 @objc(GTMAuthSessionDelegateProvider)
 public class AuthSessionDelegateProvider: NSObject, AuthSessionDelegate {
-
   /// The `AuthSession` to which this delegate was given.
   @objc public var originalAuthSession: AuthSession?
 

--- a/GTMAppAuth/Tests/Helpers/AuthorizationTestingHelp.swift
+++ b/GTMAppAuth/Tests/Helpers/AuthorizationTestingHelp.swift
@@ -128,19 +128,7 @@ public class AuthSessionDelegateProvider: NSObject, AuthSessionDelegate {
     return [:]
   }
 
-  public func updatedError(
-    forAuthSession authSession: AuthSession,
-    originalError: Error
-  ) -> Error? {
-    XCTAssertEqual(authSession, originalAuthSession)
-    updatedErrorCalled = true
-    guard let expectedError = expectedError else {
-      return nil
-    }
-    return expectedError
-  }
-
-  public func updatedError(
+  public func updateError(
     forAuthSession authSession: AuthSession,
     originalError: Error,
     completion: @escaping (Error?) -> Void

--- a/GTMAppAuth/Tests/Unit/AuthSessionTests.swift
+++ b/GTMAppAuth/Tests/Unit/AuthSessionTests.swift
@@ -276,9 +276,6 @@ class AuthSessionTests: XCTestCase {
       authState: OIDAuthState.testInstance()
     )
 
-    // The error we expect from the
-    // `AuthSessionDelegate.updatedError(forAuthSession:error:)` callback
-    let expectedCustomErrorDomain = "SomeCustomDomain"
     // There must be an error here for the delegate to get the `updatedError` callback
     let insecureRequest = NSMutableURLRequest(url: insecureFakeURL)
     let expectedError = AuthSession.Error.cannotAuthorizeRequest(insecureRequest as URLRequest)


### PR DESCRIPTION
This change adds a completion argument for handling updated errors in EMM flow (e.g., https://github.com/google/GoogleSignIn-iOS/pull/299). 