### PR TITLE
KeychainAttribute: Return correct names of keychain attributes

### DIFF
--- a/GTMAppAuth/Sources/KeychainStore/KeychainAttribute.swift
+++ b/GTMAppAuth/Sources/KeychainStore/KeychainAttribute.swift
@@ -24,6 +24,7 @@ public final class KeychainAttribute: NSObject {
     /// Indicates whether to treat macOS keychain items like iOS keychain items.
     ///
     /// This attribute will set `kSecUseDataProtectionKeychain` as true in the Keychain query.
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     case useDataProtectionKeychain
     /// The `String` name for the access group to use in the Keychain query.
     case accessGroup(String)
@@ -32,9 +33,13 @@ public final class KeychainAttribute: NSObject {
     public var keyName: String {
       switch self {
       case .useDataProtectionKeychain:
-        return "kSecUseDataProtectionKeychain"
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+          return kSecUseDataProtectionKeychain as String
+        }
+
+        fatalError(".useDataProtectionKeychain is not available")
       case .accessGroup:
-        return "kSecKeychainAccessGroup"
+        return kSecAttrAccessGroup as String
       }
     }
   }
@@ -53,7 +58,7 @@ public final class KeychainAttribute: NSObject {
   /// Creates an instance of `KeychainAttribute` whose attribute is set to
   /// `.useDataProtectionKeychain`.
   /// - Returns: An instance of `KeychainAttribute`.
-  @available(macOS 10.15, *)
+  @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
   @objc public static let useDataProtectionKeychain = KeychainAttribute(
     attribute: .useDataProtectionKeychain
   )

--- a/GTMAppAuth/Sources/KeychainStore/KeychainHelper.swift
+++ b/GTMAppAuth/Sources/KeychainStore/KeychainHelper.swift
@@ -34,11 +34,6 @@ public protocol KeychainHelper {
 final class KeychainWrapper: KeychainHelper {
   let accountName = "OAuth"
   let keychainAttributes: Set<KeychainAttribute>
-  @available(macOS 10.15, *)
-  private var isMaxMacOSVersionGreaterThanTenOneFive: Bool {
-    let tenOneFive = OperatingSystemVersion(majorVersion: 10, minorVersion: 15, patchVersion: 0)
-    return ProcessInfo().isOperatingSystemAtLeast(tenOneFive)
-  }
 
   init(keychainAttributes: Set<KeychainAttribute> = []) {
     self.keychainAttributes = keychainAttributes
@@ -54,11 +49,7 @@ final class KeychainWrapper: KeychainHelper {
     keychainAttributes.forEach { configuration in
       switch configuration.attribute {
       case .useDataProtectionKeychain:
-#if os(macOS) && isMaxMacOSVersionGreaterThanTenOneFive
-        if #available(macOS 10.15, *) {
           query[configuration.attribute.keyName] = kCFBooleanTrue
-        }
-#endif
       case .accessGroup(let name):
         query[configuration.attribute.keyName] = name
       }

--- a/GTMAppAuth/Tests/Unit/KeychainStore/KeychainStoreTests.swift
+++ b/GTMAppAuth/Tests/Unit/KeychainStore/KeychainStoreTests.swift
@@ -66,6 +66,8 @@ class KeychainStoreTests: XCTestCase {
       return
     }
 
+    XCTAssertEqual(testQuery[kSecUseDataProtectionKeychain as String], kCFBooleanTrue)
+
     let comparisonQuery = comparisonKeychainQuery(
       withAttributes: useDataProtectionAttributeSet,
       accountName: fakeWithDataProtection.accountName,
@@ -92,6 +94,8 @@ class KeychainStoreTests: XCTestCase {
       XCTFail("`fakeWithAccessGroup` missing keychain query attributes")
       return
     }
+
+    XCTAssertEqual(testQuery[kSecAttrAccessGroup as String], expectedGroupName)
 
     let comparisonQuery = comparisonKeychainQuery(
       withAttributes: accessGroupAttributeSet,
@@ -129,6 +133,9 @@ class KeychainStoreTests: XCTestCase {
       XCTFail("`fakeWithDataProtectionAndAccessGroup` missing keychain query attributes")
       return
     }
+
+    XCTAssertEqual(testQuery[kSecUseDataProtectionKeychain as String], kCFBooleanTrue)
+    XCTAssertEqual(testQuery[kSecAttrAccessGroup as String], expectedGroupName)
 
     let comparisonQuery = comparisonKeychainQuery(
       withAttributes: accessGroupAttributeSet,
@@ -172,6 +179,8 @@ class KeychainStoreTests: XCTestCase {
       return
     }
 
+    XCTAssertEqual(testQuery[kSecUseDataProtectionKeychain as String], kCFBooleanTrue)
+
     let comparisonQuery = comparisonKeychainQuery(
       withAttributes: useDataProtectionAttributeSet,
       accountName: fakeWithDataProtection.accountName,
@@ -199,6 +208,8 @@ class KeychainStoreTests: XCTestCase {
       XCTFail("`fakeWithAccessGroup` missing keychain query attributes")
       return
     }
+
+    XCTAssertEqual(testQuery[kSecAttrAccessGroup as String], expectedGroupName)
 
     let comparisonQuery = comparisonKeychainQuery(
       withAttributes: accessGroupAttributeSet,
@@ -237,6 +248,9 @@ class KeychainStoreTests: XCTestCase {
       XCTFail("`fakeWithDataProtectionAndAccessGroup` missing keychain query attributes")
       return
     }
+
+    XCTAssertEqual(testQuery[kSecUseDataProtectionKeychain as String], kCFBooleanTrue)
+    XCTAssertEqual(testQuery[kSecAttrAccessGroup as String], expectedGroupName)
 
     let comparisonQuery = comparisonKeychainQuery(
       withAttributes: accessGroupAttributeSet,
@@ -280,6 +294,8 @@ class KeychainStoreTests: XCTestCase {
       return
     }
 
+    XCTAssertEqual(testQuery[kSecUseDataProtectionKeychain as String], kCFBooleanTrue)
+
     let comparisonQuery = comparisonKeychainQuery(
       withAttributes: useDataProtectionAttributeSet,
       accountName: fakeWithDataProtection.accountName,
@@ -307,6 +323,8 @@ class KeychainStoreTests: XCTestCase {
       XCTFail("`fakeWithAccessGroup` missing keychain query attributes")
       return
     }
+
+    XCTAssertEqual(testQuery[kSecAttrAccessGroup as String], expectedGroupName)
 
     let comparisonQuery = comparisonKeychainQuery(
       withAttributes: accessGroupAttributeSet,
@@ -345,6 +363,9 @@ class KeychainStoreTests: XCTestCase {
       XCTFail("`fakeWithDataProtectionAndAccessGroup` missing keychain query attributes")
       return
     }
+
+    XCTAssertEqual(testQuery[kSecUseDataProtectionKeychain as String], kCFBooleanTrue)
+    XCTAssertEqual(testQuery[kSecAttrAccessGroup as String], expectedGroupName)
 
     let comparisonQuery = comparisonKeychainQuery(
       withAttributes: accessGroupAttributeSet,


### PR DESCRIPTION
This commit fixes issue google/GTMAppAuth#236:
KeychainAttribute.keyName should not return the quoted constants but rather the Foundation constants itself -- e.g. kSecUseDataProtectionKeychain instead of "kSecUseDataProtectionKeychain".  KeychainWrapper uses the return value as-is to assemble the query dictionary for SecItem(Add|Delete|CopyMatching). Therefore, using the wrong property names means the attributes never had any effect.