### PR TITLE
Remove macOS-11 runner

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12]
+        os: [macos-12]
   
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This runner has been deprecated and removed (per [this failure](https://github.com/google/GTMAppAuth/actions/runs/9722670542)).