### PR TITLE
Update upload artifact action to use v4.6.2

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -49,7 +49,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag=v4.6.2
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -49,7 +49,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # tag=v3.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
V3 is deprecated as of November 30, 2024 https://github.com/actions/upload-artifact?tab=readme-ov-file#actionsupload-artifact.