### PR TITLE
Update scorecards.yml to allow run on workflow_dispatch

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -6,6 +6,7 @@ on:
     - cron: '20 23 * * 4'
   push:
     branches: [ "master" ]
+  workflow_dispatch:
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
This change allows us to test https://github.com/google/GTMAppAuth/pull/260. This will allow us to manually trigger the "Scorecards supply-chain security" action.