### PR TITLE
Fix Swift 6 mode `@Sendable` closure warning.

### DIFF
--- a/GTMAppAuth/Sources/AuthSession.swift
+++ b/GTMAppAuth/Sources/AuthSession.swift
@@ -286,6 +286,7 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
     let callbackQueue = fetcherService?.callbackQueue ?? DispatchQueue.main
 
     let callback: () -> Void = {
+      let requestCopy = request as URLRequest
       callbackQueue.async {
         switch args.callbackStyle {
         case .completion(let callback):
@@ -294,7 +295,7 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
           self.invokeCallback(
             withDelegate: delegate,
             selector: selector,
-            request: request,
+            request: requestCopy,
             error: args.error
           )
         }
@@ -315,7 +316,7 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
   private func invokeCallback(
     withDelegate delegate: Any,
     selector: Selector,
-    request: NSMutableURLRequest,
+    request: URLRequest,
     error: Swift.Error?
   ) {
     guard let delegate = delegate as? NSObject, delegate.responds(to: selector) else {
@@ -327,7 +328,7 @@ public final class AuthSession: NSObject, GTMSessionFetcherAuthorizer, NSSecureC
       NSObject,
       Selector,
       AuthSession,
-      NSMutableURLRequest,
+      URLRequest,
       NSError?
     ) -> Void
     let authorizeRequest: DelegateCallback = unsafeBitCast(

--- a/GTMAppAuth/Tests/ObjCIntegration/GTMAuthSessionTests.m
+++ b/GTMAppAuth/Tests/ObjCIntegration/GTMAuthSessionTests.m
@@ -169,7 +169,7 @@
   [self waitForExpectations:@[delegateExpectation] timeout:self.expectationTimeout];
 
   XCTAssertNotNil(testingDelegate.passedRequest);
-  XCTAssertEqual(originalRequest, testingDelegate.passedRequest);
+  XCTAssertEqualObjects(originalRequest, testingDelegate.passedRequest);
   XCTAssertNotNil(testingDelegate.passedAuthorization);
   XCTAssertEqual(originalAuthorization, testingDelegate.passedAuthorization);
   XCTAssertNil(testingDelegate.passedError);


### PR DESCRIPTION
Our current implementation of sending a `NSMutableURLRequest` in a `DispatchQueue.main.async` gives a warning that will be an error in Swift 6:
```
Capture of 'request' with non-sendable type 'NSMutableURLRequest' in a `@Sendable` closure; this is an error in the Swift 6 language mode
```
Swift 6 suggests that sending in an object that does not conform to the Sendable protocol is unsafe when dealing with multiple threads, so this PR suggests a switch to use `URLRequest` which does conform to the Sendable protocol. 

Fixes #249