### PR TITLE
Update macos runner to macos-13

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12]
+        os: [macos-13]
   
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
macos-12 has been deprecated for a good bit, and the build workflow has been failing during this time.