### PR TITLE
Support swift 6

### DIFF
--- a/GTMAppAuth/Sources/KeychainStore/GTMOAuth2Compatibility.swift
+++ b/GTMAppAuth/Sources/KeychainStore/GTMOAuth2Compatibility.swift
@@ -108,10 +108,10 @@ public final class GTMOAuth2Compatibility: NSObject {
     return originalString.addingPercentEncoding(withAllowedCharacters: urlQueryCharacters)
   }
 
-  private static var googleAuthorizationURL = URL(string: "https://accounts.google.com/o/oauth2/v2/auth")!
+  private static let googleAuthorizationURL = URL(string: "https://accounts.google.com/o/oauth2/v2/auth")!
   static let googleTokenURL = URL(string: "https://www.googleapis.com/oauth2/v4/token")!
-  static var googleRevocationURL = URL(string: "https://accounts.google.com/o/oauth2/revoke")!
-  static var googleUserInfoURL = URL(string: "https://www.googleapis.com/oauth2/v3/userinfo")!
+  static let googleRevocationURL = URL(string: "https://accounts.google.com/o/oauth2/revoke")!
+  static let googleUserInfoURL = URL(string: "https://www.googleapis.com/oauth2/v3/userinfo")!
   static var nativeClientRedirectURI: String {
     return oobString
   }

--- a/GTMAppAuth/Sources/KeychainStore/KeychainAttribute.swift
+++ b/GTMAppAuth/Sources/KeychainStore/KeychainAttribute.swift
@@ -18,9 +18,9 @@ import Foundation
 
 /// The Keychain attribute used to configure the way the keychain stores your items.
 @objc(GTMKeychainAttribute)
-public final class KeychainAttribute: NSObject {
+public final class KeychainAttribute: NSObject, Sendable {
   /// An enumeratiion listing the various attributes used to configure the Keychain.
-  public enum Attribute {
+  public enum Attribute: Sendable {
     /// Indicates whether to use the legacy file-based keychain on macOS.
     ///
     /// This attribute will set `kSecUseDataProtectionKeychain` as `false` in the Keychain query.

--- a/Package.swift
+++ b/Package.swift
@@ -73,5 +73,6 @@ let package = Package(
       ],
       path: "GTMAppAuth/Tests/ObjCIntegration"
     )
-  ]
+  ],
+  swiftLanguageVersions: [.version("6")]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -73,6 +73,5 @@ let package = Package(
       ],
       path: "GTMAppAuth/Tests/ObjCIntegration"
     )
-  ],
-  swiftLanguageVersions: [.version("6")]
+  ]
 )


### PR DESCRIPTION
This PR fixing compile errors when using Swift 6. 

Tested: Example-iOS (Example-macOS.xcodeproj) compiles on iOS 26 iPhone 16 simulator with `swiftLanguageVersions: [.version("6")]` set in Package.swift. 

Closes: #258