### PR TITLE
Use macos-latest instead of hardcoded version number

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13]
+        os: [macos-latest]
   
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Using macos-latest will help us to keep our nightly builds working when OSes get deprecated (e.g., https://github.com/actions/runner-images/issues/13046).