### PR TITLE
Xcode 27 + AppAuth 3.0.0 Support

### DIFF
--- a/Examples/Example-iOS/Example-iOS.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS/Example-iOS.xcodeproj/project.pbxproj
@@ -252,7 +252,7 @@
 					"../Source/**",
 					../../../../../,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -295,7 +295,7 @@
 					"../Source/**",
 					../../../../../,
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Examples/Example-iOS/Example-iOS.xcodeproj/project.pbxproj
+++ b/Examples/Example-iOS/Example-iOS.xcodeproj/project.pbxproj
@@ -370,7 +370,7 @@
 			repositoryURL = "https://github.com/openid/AppAuth-iOS.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				minimumVersion = 3.0.0;
 			};
 		};
 		C1B5D3602825A4900068D12B /* XCRemoteSwiftPackageReference "gtm-session-fetcher" */ = {

--- a/Examples/Example-iOS/Source/SceneDelegate.m
+++ b/Examples/Example-iOS/Source/SceneDelegate.m
@@ -40,7 +40,7 @@
   if (!context) {
     return;
   }
-  if ([self.currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:context.URL]) {
+  if ([self.currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:context.URL error:NULL]) {
     self.currentAuthorizationFlow = nil;
   }
 }

--- a/Examples/Example-macOS/Example-macOS.xcodeproj/project.pbxproj
+++ b/Examples/Example-macOS/Example-macOS.xcodeproj/project.pbxproj
@@ -246,7 +246,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -284,7 +284,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 			};
@@ -359,7 +359,7 @@
 			repositoryURL = "https://github.com/openid/AppAuth-iOS.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 3.0.0;
 			};
 		};
 		C1B5D3692825B0C30068D12B /* XCRemoteSwiftPackageReference "gtm-session-fetcher" */ = {

--- a/Examples/Example-macOS/Source/AppDelegate.m
+++ b/Examples/Example-macOS/Source/AppDelegate.m
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
            withReplyEvent:(NSAppleEventDescriptor *)replyEvent {
   NSString *URLString = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
   NSURL *URL = [NSURL URLWithString:URLString];
-  [_currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:URL];
+  [_currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:URL error:NULL];
 }
 
 @end

--- a/GTMAppAuth.podspec
+++ b/GTMAppAuth.podspec
@@ -25,10 +25,10 @@ requests with AppAuth.
     "GTMAppAuth_Privacy" => "GTMAppAuth/Sources/Resources/PrivacyInfo.xcprivacy"
   }
 
-  ios_deployment_target = '12.0'
-  osx_deployment_target = '10.12'
-  tvos_deployment_target = '10.0'
-  watchos_deployment_target = '6.0'
+  ios_deployment_target = '15.0'
+  osx_deployment_target = '12.0'
+  tvos_deployment_target = '15.0'
+  watchos_deployment_target = '9.0'
   s.ios.deployment_target = ios_deployment_target
   s.osx.deployment_target = osx_deployment_target
   s.tvos.deployment_target = tvos_deployment_target
@@ -36,7 +36,7 @@ requests with AppAuth.
 
   s.framework = 'Security'
   s.dependency 'GTMSessionFetcher/Core', '>= 3.3', '< 4.0'
-  s.dependency 'AppAuth/Core', '~> 2.0'
+  s.dependency 'AppAuth/Core', '~> 3.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.platforms = {

--- a/GTMAppAuth/Sources/KeychainStore/KeychainAttribute.swift
+++ b/GTMAppAuth/Sources/KeychainStore/KeychainAttribute.swift
@@ -32,11 +32,7 @@ public final class KeychainAttribute: NSObject, Sendable {
     public var keyName: String {
       switch self {
       case .useFileBasedKeychain:
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
-          return kSecUseDataProtectionKeychain as String
-        } else {
-          fatalError("`kSecUseDataProtectionKeychain is only available on macOS 10.15 and greater")
-        }
+        return kSecUseDataProtectionKeychain as String
       case .accessGroup:
         return kSecAttrAccessGroup as String
       }

--- a/GTMAppAuth/Sources/KeychainStore/KeychainHelper.swift
+++ b/GTMAppAuth/Sources/KeychainStore/KeychainHelper.swift
@@ -47,16 +47,12 @@ final class KeychainWrapper: KeychainHelper {
       kSecAttrService as String: service,
     ]
 
-    if #available(macOS 10.15, macCatalyst 13.1, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
-      query[kSecUseDataProtectionKeychain as String] = kCFBooleanTrue
-    }
+    query[kSecUseDataProtectionKeychain as String] = kCFBooleanTrue
 
     keychainAttributes.forEach { configuration in
       switch configuration.attribute {
       case .useFileBasedKeychain:
-        if #available(macOS 10.15, macCatalyst 13.1, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
-          query[configuration.attribute.keyName] = kCFBooleanFalse
-        }
+        query[configuration.attribute.keyName] = kCFBooleanFalse
       case .accessGroup(let name):
         query[configuration.attribute.keyName] = name
       }

--- a/GTMAppAuth/Sources/KeychainStore/KeychainStore.swift
+++ b/GTMAppAuth/Sources/KeychainStore/KeychainStore.swift
@@ -116,15 +116,13 @@ public final class KeychainStore: NSObject, AuthSessionStore {
     let authSessionData = try authSessionData(fromAuthSession: authSession)
 
     var maybeAccessibility: CFString? = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-    if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
     // On macOS, we must use `kSecUseDataProtectionKeychain` if using `kSecAttrAccessible`
     // (https://developer.apple.com/documentation/security/ksecattraccessible?language=objc)
 #if os(macOS)
-      if keychainAttributes.contains(.useFileBasedKeychain) {
-        maybeAccessibility = nil
-      }
-#endif
+    if keychainAttributes.contains(.useFileBasedKeychain) {
+      maybeAccessibility = nil
     }
+#endif
 
     try keychainHelper.setPassword(
       data: authSessionData,
@@ -136,12 +134,7 @@ public final class KeychainStore: NSObject, AuthSessionStore {
   private func authSessionData(
     fromAuthSession authSession: AuthSession
   ) throws -> Data {
-    let keyedArchiver: NSKeyedArchiver
-    if #available(iOS 12, macOS 10.13, tvOS 11.0, watchOS 4.0, *) {
-      keyedArchiver = NSKeyedArchiver(requiringSecureCoding: true)
-    } else {
-      keyedArchiver = NSKeyedArchiver()
-    }
+    let keyedArchiver = NSKeyedArchiver(requiringSecureCoding: true)
 
     // The previous name for `AuthSession` was `GTMAppAuthFetcherAuthorization`. To allow legacy
     // versions of this library to unarchive and archive instances of `AuthSession` from new
@@ -169,14 +162,8 @@ public final class KeychainStore: NSObject, AuthSessionStore {
   }
 
   private func keyedUnarchiver(forData data: Data) throws -> NSKeyedUnarchiver {
-    let keyedUnarchiver: NSKeyedUnarchiver
-    if #available(iOS 12.0, macOS 10.13, watchOS 4.0, tvOS 11.0, *) {
-      keyedUnarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
-      keyedUnarchiver.requiresSecureCoding = true
-    } else {
-      keyedUnarchiver = NSKeyedUnarchiver(forReadingWith: data)
-      keyedUnarchiver.requiresSecureCoding = false
-    }
+    let keyedUnarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+    keyedUnarchiver.requiresSecureCoding = true
     // The previous name for `AuthSession` was `GTMAppAuthFetcherAuthorization` and so unarchiving
     // requires mapping the name previous instances were archived under to the new name.
     keyedUnarchiver.setClass(AuthSession.self, forClassName: AuthSession.legacyArchiveName)
@@ -277,16 +264,14 @@ public final class KeychainStore: NSObject, AuthSessionStore {
       throw KeychainStore.Error.failedToCreateResponseStringFromAuthSession(authSession)
     }
 
-    if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
     // On macOS, we must use `kSecUseDataProtectionKeychain` if using `kSecAttrAccessible`
     // (https://developer.apple.com/documentation/security/ksecattraccessible?language=objc)
 #if os(macOS)
-      if keychainAttributes.contains(.useFileBasedKeychain) {
-        try keychainHelper.setPassword(persistence, forService: itemName)
-        return
-      }
-#endif
+    if keychainAttributes.contains(.useFileBasedKeychain) {
+      try keychainHelper.setPassword(persistence, forService: itemName)
+      return
     }
+#endif
 
     try keychainHelper.setPassword(
       persistence,

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // Copyright 2021 Google LLC
@@ -20,10 +20,10 @@ import PackageDescription
 let package = Package(
   name: "GTMAppAuth",
   platforms: [
-    .macOS(.v10_12),
-    .iOS(.v12),
-    .tvOS(.v10),
-    .watchOS(.v6)
+    .macOS(.v12),
+    .iOS(.v15),
+    .tvOS(.v15),
+    .watchOS(.v9)
   ],
   products: [
     .library(
@@ -33,7 +33,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/google/gtm-session-fetcher.git", "3.3.0" ..< "4.0.0"),
-    .package(url: "https://github.com/openid/AppAuth-iOS.git", "2.0.0" ..< "3.0.0")
+    .package(url: "https://github.com/openid/AppAuth-iOS.git", "3.0.0" ..< "4.0.0")
   ],
   targets: [
     .target(


### PR DESCRIPTION
This PR:
- updates all target minimums + SPM tools version to the minimums required by Xcode 27.
- bumps the AppAuth version to 3.0.0 (this will not pass CI until 3.0.0 reaches the trunk).
- removes some no-longer-relevant guards / version checks.

Xcode 27 will be releasing soon. AppAuth <3.0.0 does not build on Xcode <27, so, this PR updates that as well as GTMAppAuth's own minimums.